### PR TITLE
add language option "IgnoreUnreachableMatches"

### DIFF
--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -101,6 +101,14 @@ public:
   MonoTypePtr readMonoType(const std::string&);
   void setReadExprFn(readExprFn);
 
+  struct UnreachableMatches {
+    LexicalAnnotation la;
+    std::string lines;
+  };
+  typedef void (*gatherUnreachableMatchesFn)(const UnreachableMatches&);
+  void gatherUnreachableMatches(const UnreachableMatches& m);
+  void setGatherUnreachableMatchesFn(gatherUnreachableMatchesFn f);
+
   // search for paths from one type to another
   // (currently just one-step paths, may be useful to consider multi-step paths)
   SearchEntries search(const MonoTypePtr&, const MonoTypePtr&);
@@ -113,6 +121,9 @@ private:
   readModuleFn     readModuleF;
   readExprDefnFn   readExprDefnF;
   readExprFn       readExprF;
+
+  gatherUnreachableMatchesFn gatherUnreachableMatchesF = [](const UnreachableMatches&){};
+
 public:
   // type-safe compilation to C++ function pointers
   template <typename RFn, typename ... NamesAndExpr>
@@ -250,6 +261,8 @@ public:
   bool buildInterpretedMatches() const;
   void requireMatchReachability(bool f);
   bool requireMatchReachability() const;
+  void ignoreUnreachableMatches(bool f);
+  bool ignoreUnreachableMatches() const;
   void alwaysLowerPrimMatchTables(bool);
   bool alwaysLowerPrimMatchTables() const;
   void buildColumnwiseMatches(bool f);
@@ -260,9 +273,6 @@ public:
   bool throwOnHugeRegexDFA() const;
   void regexDFAOverNFAMaxRatio(int f);
   int  regexDFAOverNFAMaxRatio() const;
-
-  // allow caller to gather a vector of unreachable rows arising from match compilation
-  UnreachableMatchRowsPtr unreachableMatchRowsPtr;
 
   // allow low-level functions to be added
   void bindLLFunc(const std::string&, op*);
@@ -290,6 +300,7 @@ private:
   bool runModInlinePass;
   bool genInterpretedMatch;
   bool checkMatchReachability;
+  bool ignoreUnreachablePatternMatchRows = false;
   bool lowerPrimMatchTables;
   bool columnwiseMatches;
   size_t maxExprDFASize={1000};

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -44,7 +44,6 @@ cc::cc() :
   readExprDefnF(&defReadExprDefn),
   readExprF(&defReadExpr),
   drainingDefs(false),
-  unreachableMatchRowsPtr(nullptr),
   runModInlinePass(true),
   genInterpretedMatch(false),
   checkMatchReachability(true),
@@ -164,6 +163,9 @@ MonoTypePtr cc::readMonoType(const std::string& x) {
     throw std::runtime_error("Couldn't parse as type: " + x);
   }
 }
+
+void cc::gatherUnreachableMatches(const UnreachableMatches& m) { hlock _; this->gatherUnreachableMatchesF(m); }
+void cc::setGatherUnreachableMatchesFn(gatherUnreachableMatchesFn f) { this->gatherUnreachableMatchesF = f; }
 
 ExprPtr cc::unsweetenExpression(const TEnvPtr& te, const ExprPtr& e) {
   return unsweetenExpression(te, "", e);
@@ -655,6 +657,9 @@ bool cc::buildInterpretedMatches() const { return this->genInterpretedMatch; }
 void cc::requireMatchReachability(bool f) { this->checkMatchReachability = f; }
 bool cc::requireMatchReachability() const { return this->checkMatchReachability; }
 
+void cc::ignoreUnreachableMatches(bool f) { this->ignoreUnreachablePatternMatchRows = f; }
+bool cc::ignoreUnreachableMatches() const { return this->ignoreUnreachablePatternMatchRows; }
+
 void cc::alwaysLowerPrimMatchTables(bool f) { this->lowerPrimMatchTables = f; }
 bool cc::alwaysLowerPrimMatchTables() const { return this->lowerPrimMatchTables; }
 
@@ -663,7 +668,7 @@ bool cc::buildColumnwiseMatches() const { return this->columnwiseMatches; }
 
 void cc::regexMaxExprDFASize(size_t f) { this->maxExprDFASize = f; }
 size_t cc::regexMaxExprDFASize() const { return this->maxExprDFASize; }
-  
+
 void cc::throwOnHugeRegexDFA(bool f) { this->shouldThrowOnHugeRegexDFA = f; }
 bool cc::throwOnHugeRegexDFA() const { return this-> shouldThrowOnHugeRegexDFA; }
 

--- a/lib/hobbes/eval/cmodule.C
+++ b/lib/hobbes/eval/cmodule.C
@@ -1003,6 +1003,7 @@ OptDescs getAllOptions() {
   d["SafeArrays"] =
       "Interpret array indexing 'safely' (always bounds-checked and mapped to "
       "an optional type in case of out-of-bounds access)";
+  d["IgnoreUnreachableMatches"] = "Ignore unreachable pattern match rows";
   return d;
 }
 
@@ -1028,6 +1029,10 @@ ExprPtr translateExprWithOpts(
           {"SafeArrays",
            [](std::string const &, const ExprPtr &e) -> ExprPtr {
              return switchOf(e, makeSafeArrays());
+           }},
+          {"IgnoreUnreachableMatches",
+           [](std::string const &, const ExprPtr &e) -> ExprPtr {
+             return e;
            }},
       };
   thread_local auto ignoreFn = [](std::string const &optName,

--- a/lib/hobbes/lang/module.C
+++ b/lib/hobbes/lang/module.C
@@ -20,7 +20,7 @@ void Module::show(std::ostream& out) const {
 }
 
 bool isValidOption(const std::string& o) {
-  return o == "Safe" || o == "SafeArrays";
+  return o == "Safe" || o == "SafeArrays" || o == "IgnoreUnreachableMatches";
 }
 
 void Module::setOption(const std::string& o, const LexicalAnnotation& la) {

--- a/lib/hobbes/lang/pat/dfa.C
+++ b/lib/hobbes/lang/pat/dfa.C
@@ -1133,29 +1133,22 @@ stateidx_t makeDFA(MDFA* dfa, const PatternRows& ps, const LexicalAnnotation& la
     std::vector<size_t> unreachableRows;
     for (size_t r = 0; r < ps.size(); ++r) {
       size_t fs = finalStates[r];
- 
+
       if (dfa->states[fs]->refs == 0) {
         unreachableRows.push_back(r);
       }
     }
-  
+
     if (unreachableRows.size() > 0) {
       std::ostringstream fss;
       fss << "Unreachable row" << (unreachableRows.size() > 1 ? "s" : "") << " in match expression:\n";
       for (size_t ur : unreachableRows) {
         fss << "  " << show(ps[ur]) << std::endl;
       }
-      throw annotated_error(la, fss.str());
-    }
-  }
-
-  // save unreachable rows for the caller instead of raising an error
-  if (dfa->c->unreachableMatchRowsPtr) {
-    for (size_t r = 0; r < ps.size(); ++r) {
-      size_t fs = finalStates[r];
-
-      if (dfa->states[fs]->refs == 0) {
-        dfa->c->unreachableMatchRowsPtr->push_back(std::make_pair(r, ps[r]));
+      if (dfa->c->ignoreUnreachableMatches()) {
+        dfa->c->gatherUnreachableMatches({.la = la, .lines = fss.str()});
+      } else {
+        throw annotated_error(la, fss.str());
       }
     }
   }

--- a/test/Main.C
+++ b/test/Main.C
@@ -75,7 +75,7 @@ int TestCoord::runTestGroups(const Args& args) {
   std::cout << "---------------------------------------------------------------------" << std::endl
             << hobbes::describeNanoTime(hobbes::tick()-tt0) << std::endl;
 
-  if (failures.size() > 0) {
+  if (!failures.empty()) {
     std::cout << "\n\nFAILURE" << (failures.size() == 1 ? "" : "S") << ":" << std::endl
               << "---------------------------------------------------------------------" << std::endl;
     for (const auto& failure : failures) {
@@ -83,7 +83,7 @@ int TestCoord::runTestGroups(const Args& args) {
     }
   }
 
-  if (auto path = args.report) {
+  if (const auto* path = args.report) {
     std::ofstream outfile(path, std::ios::out | std::ios::trunc);
     if (outfile) {
       outfile << toJSON();


### PR DESCRIPTION
User might need to add ad-hoc change to disable some matching rows, the original behavior of hobbes considers unreachable rows as an error, for example, if we have a `tt.hob`

```
foo x y = match x y with
  | 0 0 -> "zero/zero"
  | _ _ -> "wildcard"
  | 1 _ -> "unreachable"
  | _ 1 -> "unreachable"

add2 x = x + 2

bar x y = match x y with
  | 1 1 -> "one/one"
  | _ _ -> "wildcard"
  | _ 7 -> "unreachable"
  | 7 _ -> "unreachable"
```
Both `foo` and `bar` have 3 rows of unreachable patterns, the current behavior is
```
$ ./hi -s tt.hob
tt.hob:1,11-5,23: Unreachable rows in match expression:
  1 .t19610 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]
  .t19611 1 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]

1 foo x y = match x y with
2   | 0 0 -> "zero/zero"
3   | _ _ -> "wildcard"
4   | 1 _ -> "unreachable"
5   | _ 1 -> "unreachable"
6
7 add2 x = x + 2
8
9 bar x y = match x y with
```

```
> :l tt.hob
tt.hob:1,11-5,23: Unreachable rows in match expression:
  1 .t19610 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]
  .t19611 1 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]

1 foo x y = match x y with
2   | 0 0 -> "zero/zero"
3   | _ _ -> "wildcard"
4   | 1 _ -> "unreachable"
5   | _ 1 -> "unreachable"
6
7 add2 x = x + 2
8
9 bar x y = match x y with
```

They both stops execution and exit with error code

With newly added `IgnoreUnreachableMatches` language option, we can achieve something like

```
$ ./hi -s -o IgnoreUnreachableMatches tt.hob
warning: tt.hob:tt.hob:1,11-5,23    Unreachable rows in match expression:
  1 .t19610 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]
  .t19611 1 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]

warning: tt.hob:tt.hob:9,11-13,23    Unreachable rows in match expression:
  .t19620 7 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]
  7 .t19621 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]

> add2(3)
5
> foo(0, 0)
"zero/zero"
> bar(9, 10)
"wildcard"
> bar(7, 10)
"wildcard"
```

```
> :o IgnoreUnreachableMatches
> :l tt.hob
warning: tt.hob:tt.hob:1,11-5,23    Unreachable rows in match expression:
  1 .t19620 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]
  .t19621 1 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]

warning: tt.hob:tt.hob:9,11-13,23    Unreachable rows in match expression:
  .t19630 7 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]
  7 .t19631 -> ['u', 'n', 'r', 'e', 'a', 'c', 'h', 'a', 'b', 'l', 'e']::[char]

loaded module 'tt.hob'
> add2(3)
5
```

The default behavior of this option is a noop. In `hi`, we can easily define a custom function and make it print related info as warnings

```cpp
void defPrintUnreachableMatches(const hobbes::cc::UnreachableMatches& m) {
  std::cout << "warning: " << m.la.filename() << ':' << m.la.lineDesc() << "    " << m.lines << std::endl;
}

void some_func() {
  this->ctx.ignoreUnreachableMatches(true);
  this->ctx.setGatherUnreachableMatchesFn(defPrintUnreachableMatches);
}
```
`this->ctx` in this code is a pointer to `hobbes::cc`