### PR TITLE
make CMakeLists.txt work with user defined LLVM location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(Curses REQUIRED)
 include_directories(${CURSES_INCLUDE_DIRS})
 
 find_package(LLVM REQUIRED CONFIG)
-include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
 if (${LLVM_PACKAGE_VERSION} VERSION_LESS "10.0")
@@ -29,7 +29,8 @@ else()
   set(jit_lib mcjit)
 endif()
 
-find_program(llvm-config llvm-config PATHS ${LLVM_TOOLS_BINARY_DIR})
+find_program(llvm-config llvm-config PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
+find_program(llvm-config llvm-config)
 if (${LLVM_PACKAGE_VERSION} VERSION_LESS "4.0")
   execute_process(COMMAND ${llvm-config} --libs x86 ipo ${jit_lib}
                   OUTPUT_VARIABLE llvm_libs


### PR DESCRIPTION
If llvm is not installed in default location, or there are multiple installations on the system, then specify `LLVM_DIR` alone is not suffice

### llvm-config path
cmake searches `LLVM-Config.cmake` under `LLVM_DIR`. However, current `CMakeLists.txt` relies on `llvm-config` to give proper compile/link flags, and `llvm-config` is still gonna be searched in default locations. The result it, `-I` and `-L` will refer to different LLVM build.

If `LLVM_DIR` and default LLVM installation on the system have different versions/build flags etc., it will throw all kinds of weird linking errors

To solve this problem, `LLVM_TOOLS_BINARY_DIR` not only has to be added to `llvm-config` search path, but also must have higher precedence.
```diff
-find_program(llvm-config llvm-config PATHS ${LLVM_TOOLS_BINARY_DIR})
+find_program(llvm-config llvm-config PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
+find_program(llvm-config llvm-config)
```

### warnings from LLVM header
Another thing is `-Werror` fails compilation because of warnings emitted from LLVM header files. To solve this, LLVM header files should be considered as `SYSTEM` header

```diff
-include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
```

### no-rtti
Because hobbes replies on RTTI, so LLVM it self must be built with RTTI support, that is not default for LLVM

If no-rtti, linking llvm with hobbes will give errors like

```
/usr/bin/ld: libhobbes.a(jitcc.C.o):(.data.rel.ro._ZTIN6hobbes8LenWatchE[_ZTIN6hobbes8LenWatchE]+0x10): undefined reference to `typeinfo for llvm::JITEventListener'
/usr/bin/ld: libhobbes.a(jitcc.C.o):(.data.rel.ro._ZTIN6hobbes5jitmmE[_ZTIN6hobbes5jitmmE]+0x10): undefined reference to `typeinfo for llvm::SectionMemoryManager
```

### to sum up

To work with custom LLVM location

LLVM must be built with an extra `-DLLVM_ENABLE_RTTI=ON`
```
cmake -DCMAKE_INSTALL_PREFIX=$HOME/llmv-project/install-10 -DLLVM_ENABLE_RTTI=ON ../llvm
```

hobbes must be built with an extra `-DLLVM_TOOLS_BINARY_DIR`
```
cmake -Bbuild -S. -DLLVM_DIR=$HOME/llmv-project/install-10/lib/cmake/llvm -DLLVM_TOOLS_BINARY_DIR=$HOME/llmv-project/install-10/bin
```