### PR TITLE
UBSan reports few misaligned addresses

### DIFF
--- a/include/hobbes/db/series.H
+++ b/include/hobbes/db/series.H
@@ -170,8 +170,8 @@ public:
 private:
   StorageMode sm;
   union {
-    char rss[sizeof(RawStoredSeries)];
-    char css[sizeof(CompressedStoredSeries)];
+    alignas(RawStoredSeries) char rss[sizeof(RawStoredSeries)];
+    alignas(CompressedStoredSeries) char css[sizeof(CompressedStoredSeries)];
   } storage;
 };
 

--- a/include/hobbes/mc/encode.H
+++ b/include/hobbes/mc/encode.H
@@ -55,7 +55,7 @@
 
 #include <sys/mman.h>
 #include <unistd.h>
-#include <string.h>
+#include <cstring>
 #include <math.h>
 
 namespace hobbes { namespace mc {
@@ -143,7 +143,7 @@ public:
   // add a label reference at the current write position (assuming a 32-bit displacement)
   void addLabelRef(const std::string& lbl) {
     this->labelRefs[lbl].push_back(this->sz);
-    *reinterpret_cast<uint32_t*>(allocate(sizeof(uint32_t))) = 0;
+    std::memset(allocate(sizeof(uint32_t)), 0, sizeof(uint32_t));
   }
 
   // define a label at the current write position
@@ -230,7 +230,8 @@ private:
         if (!canLowerTo<int32_t>(dist)) {
           throw std::runtime_error("Can't resolve label reference to '" + d->first + "' in program with jump distance greater than 32-bits");
         }
-        *reinterpret_cast<int32_t*>(this->mem + pc) = static_cast<int32_t>(dist);
+        const auto dist32 = static_cast<int32_t>(dist);
+        std::memcpy(this->mem + pc, &dist32, sizeof(dist32));
       }
     }
   }
@@ -1550,7 +1551,7 @@ inline void emitValue(buffer* b, const MODRMCode& modrm) {
   if (O == 1) {
     *b->allocate(1) = static_cast<int8_t>(modrm.disp);
   } else if (O == 2 || (O == 0 && thd_233(modrm.modrm) == 5) || (O == 0 && hasSIB && thd_233(modrm.sib) == 5)) {
-    *reinterpret_cast<int32_t*>(b->allocate(4)) = modrm.disp;
+    std::memcpy(b->allocate(4), &modrm.disp, sizeof(modrm.disp));
   }
 }
 
@@ -1622,7 +1623,7 @@ public:
           // mov rax, faddr
           (*b)[0] = REXW().byte;
           (*b)[1] = 0xb8;
-          *reinterpret_cast<const void**>(&(*b)[2]) = faddr;
+          std::memcpy(&(*b)[2], &faddr, sizeof(faddr));
 
           // call rax
           Reg<X86Reg> rax;

--- a/include/hobbes/reflect.H
+++ b/include/hobbes/reflect.H
@@ -18,7 +18,7 @@
 #include <map>
 #include <iostream>
 #include <sstream>
-#include <string.h>
+#include <cstring>
 #include <assert.h>
 #include <stdexcept>
 #include <type_traits>
@@ -1362,7 +1362,8 @@ inline bool operator!=(const desc& t0, const desc& t1) {
 template <typename T>
   T readValue(const bytes& bs, size_t* i) {
     assert((bs.size() >= (*i + sizeof(T))) && "Invalid type encoding, expected data not available");
-    T result = *reinterpret_cast<const T*>(&bs[*i]);
+    T result;
+    std::memcpy(&result, &bs[*i], sizeof(T));
     *i += sizeof(T);
     return result;
   }

--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -10,7 +10,7 @@
 #include <hobbes/util/perf.H>
 #include <sstream>
 #include <stdexcept>
-#include <string.h>
+#include <cstring>
 #include <unordered_map>
 #include <atomic>
 
@@ -2362,7 +2362,8 @@ template <typename T>
 template <typename T>
   struct readF {
     static T read(const bytes& in, unsigned int* n) {
-      T r = *reinterpret_cast<const T*>(&(in[*n]));
+      T r;
+      std::memcpy(&r, &in[*n], sizeof(T));
       *n += sizeof(T);
       return r;
     }


### PR DESCRIPTION
Running `hobbes-test` with UBSan, got errors like

```
../include/hobbes/mc/encode.H:1625:53: runtime error: store to misaligned address 0x7ffcf203b3f2 for type 'const void *', which requires 8 byte alignment
0x7ffcf203b3f2: note: pointer points here
../lib/hobbes/lang/type.C:2365:9: runtime error: load of misaligned address 0x607000e849ab for type 'const int', which requires 4 byte alignment
0x607000e849ab: note: pointer points here
.
.
.
```

1. placement new has to ensure buffer is properly aligned
2. `reinterpret_cast<T*>(p)` has to ensure `p` points to a legit `T` object, if `T` is not a byte-like type. Until we have `std::bitcast` in C++20, any casts in C++ won't start an object lift time, so this cast simply casts a memory space to a non-existing object. And `reinterpret_cast` has the alignment issue as well