### PR TITLE
memory leak in ClosureConvertF::with(const Fn*)

### DIFF
--- a/lib/hobbes/lang/closcvt.C
+++ b/lib/hobbes/lang/closcvt.C
@@ -98,7 +98,8 @@ struct ClosureConvertF : public switchExprTyFn {
 
   ExprPtr with(const Fn* v) const {
     ExprPtr nbody = switchOf(v->body(), ClosureConvertF(fnFrame(this->tenv, v->varNames()), this->roots));
-    return makeClosureOver(new Fn(v->varNames(), nbody, v->la()), excludeRootVars(setDifference(freeVars(nbody), toSet(v->varNames()))));
+    const Fn fn(v->varNames(), nbody, v->la());
+    return makeClosureOver(&fn, excludeRootVars(setDifference(freeVars(nbody), toSet(v->varNames()))));
   }
 
   ExprPtr with(const Let* v) const {


### PR DESCRIPTION
This is a low hanging fruit.

Running `hi`, before this change

```
 SUMMARY: AddressSanitizer: 632010 byte(s) leaked in 24055 allocation(s).
```

after this change

```
SUMMARY: AddressSanitizer: 500730 byte(s) leaked in 7720 allocation(s).
```