### PR TITLE
wrong cxxabi.h selected if libcxxabi installed and gcc as compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,13 @@ find_package(Curses REQUIRED)
 include_directories(${CURSES_INCLUDE_DIRS})
 
 find_package(LLVM REQUIRED CONFIG)
-include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+if (CMAKE_COMPILER_IS_GNUCXX)
+  # if libc++abi is installed, cxxabi.h in llvm path will be used
+  # have to lower llvm include path search order
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -idirafter ${LLVM_INCLUDE_DIRS}")
+else()
+  include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+endif()
 add_definitions(${LLVM_DEFINITIONS})
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
On ubuntu, if libcxxabi is installed, and gcc used as compiler, then there is a chance that an compilation error will be thrown

```
../include/hobbes/lang/preds/subtype/obj.H:52:23: error: ‘__si_class_type_info’ in namespace ‘__cxxabiv1’ does not name a type; did you mean ‘__class_type_info’?
   52 |   typedef __cxxabiv1::__si_class_type_info  si_class_type;
```

Basically, it is about wrong `cxxabi.h` in `Obj.H` gets included

This is caused by search order of include path, llvm path will be searched before system default folder, and in llvm path, there is a `cxxabi.h` installed by libcxxabi, so this one will be used instead of the one with gcc, thus compilation fails

To solve this problem, at least when compiling with gcc, llvm path has to be searched after system default path, `-idirafter` is the only solution I got

without `-idirafter`
```
#include <...> search starts here:
 ../include
 /usr/lib/llvm-10/include                      # <-- wrong cxxabi.h
 /usr/include/c++/9                             # should be this one
...
End of search list.
```

with `-idirafter`
```
#include <...> search starts here:
 ../include
 /usr/include/c++/9                            # correct order
...
 /usr/lib/llvm-10/include                     # wrong one will not be used
End of search list.
```