### PR TITLE
stop hobbes from generating large IR functions

### DIFF
--- a/include/hobbes/eval/jitcc.H
+++ b/include/hobbes/eval/jitcc.H
@@ -152,17 +152,13 @@ private:
 
 #else
 #if LLVM_VERSION_MINOR == 6 || LLVM_VERSION_MINOR == 7 || LLVM_VERSION_MINOR == 8 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR <= 12
-  llvm::legacy::PassManager* mpm;
-
   // the set of allocated execution engines (each will own a finalized module from the set of modules)
   typedef std::vector<llvm::ExecutionEngine*> ExecutionEngines;
   ExecutionEngines eengines;
 #elif LLVM_VERSION_MINOR == 3
-  llvm::PassManager*         mpm;
   llvm::ExecutionEngine*     eengine;
   llvm::FunctionPassManager* fpm;
 #elif LLVM_VERSION_MINOR == 5
-  llvm::legacy::PassManager*         mpm;
   llvm::ExecutionEngine*             eengine;
   llvm::legacy::FunctionPassManager* fpm;
 #else

--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -3,6 +3,7 @@
 #define HOBBES_UTIL_LLVM_HPP_INCLUDED
 
 #include <hobbes/util/array.H>
+#include <llvm/IR/Function.h>
 #if LLVM_VERSION_MAJOR >= 11
 #include <hobbes/lang/type.H>
 #endif
@@ -832,6 +833,44 @@ inline llvm::Value* fncall(llvm::IRBuilder<>* b, llvm::Value* fn, llvm::Type* tf
   return fncall(b, fn, tfn, list(arg));
 }
 
-}
+inline void maybeInlineFunctionsIn(llvm::Module& m) {
+  // If there is an IR function in current module is already large (instructions
+  // > `HOBBES_FUNCTION_INLINE_THRESHOLD`), then keep inlining it makes it even
+  // larger, 10x larger. We simply stop applying FunctionInlining pass on this
+  // module in such kinds of scenario.
+  static const auto allFunctionsAreSmall = [](const llvm::Module& m) {
+    static unsigned fnInliningThreshold = [] {
+      const char* v = std::getenv("HOBBES_FUNCTION_INLINE_THRESHOLD");
+      if (v == nullptr) {
+        return 30'000U; // arbitrarily chosen, but should be conservative enough
+      }
+      return static_cast<unsigned>(strtoul(v, nullptr, 10));
+    }();
 
+    // early llvm versions either don't have
+    // llvm::Function::getInstructionCount() or failed to make it const, so we
+    // provide our simplified version
+    static const auto getFunctionInstructionCount =
+        [](const llvm::Function& f) {
+          unsigned num = 0;
+          for (const auto& b : f.getBasicBlockList()) {
+            num += b.size();
+          }
+          return num;
+        };
+
+    // if any functions in this module has instruction number above threshold,
+    // then should not inline anything
+    return std::none_of(m.begin(), m.end(), [](const llvm::Function& f) {
+      return getFunctionInstructionCount(f) > fnInliningThreshold;
+    });
+  };
+
+  if (allFunctionsAreSmall(m)) {
+    auto mpm = llvm::legacy::PassManager();
+    mpm.add(llvm::createFunctionInliningPass());
+    mpm.run(m);
+  }
+}
+}
 #endif

--- a/lib/hobbes/eval/jitcc.C
+++ b/lib/hobbes/eval/jitcc.C
@@ -600,15 +600,9 @@ jitcc::jitcc(const TEnvPtr& tenv) :
   this->eengine = makeExecutionEngine(module(), 0);
 
 #if LLVM_VERSION_MINOR >= 5
-  this->mpm = new llvm::legacy::PassManager();
-  this->mpm->add(llvm::createFunctionInliningPass());
-
   this->fpm = new llvm::legacy::FunctionPassManager(module());
   this->fpm->add(new llvm::DataLayoutPass(*this->eengine->getDataLayout()));
 #else
-  this->mpm = new llvm::PassManager();
-  this->mpm->add(llvm::createFunctionInliningPass());
-
   this->fpm = new llvm::FunctionPassManager(module());
   this->fpm->add(new llvm::DataLayout(*this->eengine->getDataLayout()));
 #endif
@@ -619,11 +613,6 @@ jitcc::jitcc(const TEnvPtr& tenv) :
   this->fpm->add(llvm::createCFGSimplificationPass());
   this->fpm->add(llvm::createTailCallEliminationPass());
   this->fpm->doInitialization();
-#endif
-
-#if LLVM_VERSION_MINOR >= 6 || LLVM_VERSION_MAJOR == 4 || LLVM_VERSION_MAJOR == 6 || LLVM_VERSION_MAJOR >= 8
-  this->mpm = new llvm::legacy::PassManager();
-  this->mpm->add(llvm::createFunctionInliningPass());
 #endif
 }
 
@@ -795,8 +784,8 @@ void* jitcc::getMachineCode(llvm::Function* f, llvm::JITEventListener* listener)
     fpm.run(*mf);
   }
 
-  // apply module-level optimizations
-  this->mpm->run(*this->currentModule);
+  // may apply FunctionInliningPass depends upon some "scores"
+  maybeInlineFunctionsIn(*this->currentModule);
 
   // but we can still get at it through its execution engine
   this->eengines.push_back(ee);

--- a/lib/hobbes/eval/orcjitcc.C
+++ b/lib/hobbes/eval/orcjitcc.C
@@ -31,9 +31,8 @@ optimizeModule(llvm::orc::ThreadSafeModule tsm,
       fpm.run(f);
     }
 
-    auto mpm = llvm::legacy::PassManager();
-    mpm.add(llvm::createFunctionInliningPass());
-    mpm.run(m);
+    // may apply FunctionInliningPass depends upon some "scores"
+    hobbes::maybeInlineFunctionsIn(m);
   });
 
   return tsm;


### PR DESCRIPTION
For certain `match` input, hobbes might generate really large IR functions and it takes forever for llvm to parse

1. be conservative with "inlining" when translating DFA to IR if current DFA might have too many states
2. stop `FunctionInliningPass()` if there is one function in this module is already too large

There is a flag `buildColumnwiseMatch()` designed for preventing large DFA generation. However, the code path introduced by this flag has never been properly tested, and it has upper row count limit which is not that hard to exceed