### PR TITLE
add partial support for int128

### DIFF
--- a/include/hobbes/util/llvm.H
+++ b/include/hobbes/util/llvm.H
@@ -68,6 +68,12 @@ namespace hobbes {
 
 using int128_t = __int128;
 
+#define INT128_TO_UINT64_ARRAY_REF_NAMED_a_a_a(x)                              \
+  const uint64_t aa_aa_aa[] = {                                                \
+      static_cast<uint64_t>(static_cast<unsigned __int128>(x) &                \
+                            0xFFFFFFFFFFFFFFFF),                               \
+      static_cast<uint64_t>(static_cast<unsigned __int128>(x) >> 64U)};        \
+  const auto a_a_a = llvm::ArrayRef<uint64_t> { aa_aa_aa }
 
 #if LLVM_VERSION_MAJOR >= 11
 inline llvm::orc::ThreadSafeContext& threadSafeContext() {
@@ -218,7 +224,8 @@ inline llvm::Constant* cvalue(long x) {
 }
 
 inline llvm::Constant* cvalue(int128_t x) {
-  return llvm::Constant::getIntegerValue(int128Type(), llvm::APInt(128, x, true));
+  INT128_TO_UINT64_ARRAY_REF_NAMED_a_a_a(x);
+  return llvm::Constant::getIntegerValue(int128Type(), llvm::APInt(128, a_a_a));
 }
 
 inline llvm::Constant* cvalue(float x) {
@@ -276,7 +283,8 @@ inline llvm::ConstantInt* civalue(long x) {
 
 inline llvm::ConstantInt* civalue(int128_t x) {
   return withContext([x](llvm::LLVMContext& c) {
-    return llvm::ConstantInt::get(llvm::IntegerType::get(c, 128), x); // static_cast<uint64_t>(x));
+    INT128_TO_UINT64_ARRAY_REF_NAMED_a_a_a(x);
+    return llvm::ConstantInt::get(c, llvm::APInt(128, a_a_a));
   });
 }
 #else
@@ -431,7 +439,8 @@ inline llvm::Constant* cvalue(long x) {
 }
 
 inline llvm::Constant* cvalue(int128_t x) {
-  return llvm::Constant::getIntegerValue(int128Type(), llvm::APInt(128, x, true));
+  INT128_TO_UINT64_ARRAY_REF_NAMED_a_a_a(x);
+  return llvm::Constant::getIntegerValue(int128Type(), llvm::APInt(128, a_a_a));
 }
 
 inline llvm::Constant* cvalue(float x) {
@@ -472,10 +481,14 @@ inline llvm::ConstantInt* civalue(long x) {
 }
 
 inline llvm::ConstantInt* civalue(int128_t x) {
-  return llvm::ConstantInt::get(llvm::IntegerType::get(context(), 128), x); //static_cast<uint64_t>(x));
+  INT128_TO_UINT64_ARRAY_REF_NAMED_a_a_a(x);
+  return llvm::ConstantInt::get(context(), llvm::APInt(128, a_a_a));
 }
 
 #endif
+
+#undef INT128_TO_UINT64_ARRAY_REF_NAMED_a_a_a
+
 // an intermediate representation for records
 using FieldValue = std::pair<std::string, llvm::Value *>;
 using RecordValue = std::vector<FieldValue>;

--- a/test/Prelude.C
+++ b/test/Prelude.C
@@ -93,5 +93,11 @@ TEST(Prelude, Int128) {
   EXPECT_EQ((makeStdString(c().compileFn<const array<char>*()>("show(readInt128(\"-170141183460469231731687303715884105729\"))")())), "|0|");
   // overflow
   EXPECT_EQ((makeStdString(c().compileFn<const array<char>*()>("show(readInt128(\"170141183460469231731687303715884105728\"))")())), "|0|");
-}
 
+  // INT128_MAX
+  EXPECT_EQ((makeStdString(c().compileFn<const array<char>*()>("show(170141183460469231731687303715884105727H)")())), "170141183460469231731687303715884105727");
+  // INT128_MIN, still wrong, needs to be fixed in a separated PR
+  //EXPECT_EQ((makeStdString(c().compileFn<const array<char>*()>("show(-170141183460469231731687303715884105728H)")())), "-170141183460469231731687303715884105728");
+  // INT128_MIN - 1, better than nothing
+  EXPECT_EQ((makeStdString(c().compileFn<const array<char>*()>("show(-170141183460469231731687303715884105727H)")())), "-170141183460469231731687303715884105727");
+}


### PR DESCRIPTION
For the moment, hobbes doesn't handle int128 type well if the value is not within the range of int64

```
> 9223372036854775808H         # int64::max + 1
-9223372036854775808
> -9223372036854775809H        # int64::min - 1
9223372036854775807
```

After this change, **int128 still won't work with int128::min** because parser rewrites negative number to a `neg` function call. For example, `-3` -> `neg(3)`. However, for any integral types, abs(min) overflows. This issue will be addressed in a different PR