### PR TITLE
get cc::unmatchableRowsPtr back

### DIFF
--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -318,6 +318,8 @@ public:
   void regexDFAOverNFAMaxRatio(int f);
   int regexDFAOverNFAMaxRatio() const;
 
+  UnreachableMatchRowsPtr unreachableMatchRowsPtr;
+
   // allow low-level functions to be added
   void bindLLFunc(const std::string &, op *);
 

--- a/lib/hobbes/eval/cc.C
+++ b/lib/hobbes/eval/cc.C
@@ -45,6 +45,7 @@ cc::cc() :
   readExprDefnF(&defReadExprDefn),
   readExprF(&defReadExpr),
   drainingDefs(false),
+  unreachableMatchRowsPtr(nullptr),
   runModInlinePass(true),
   genInterpretedMatch(false),
   checkMatchReachability(true),

--- a/lib/hobbes/lang/pat/dfa.C
+++ b/lib/hobbes/lang/pat/dfa.C
@@ -1155,6 +1155,17 @@ stateidx_t makeDFA(MDFA* dfa, const PatternRows& ps, const LexicalAnnotation& la
     }
   }
 
+  if (dfa->c->unreachableMatchRowsPtr) {
+    dfa->c->unreachableMatchRowsPtr->reserve(ps.size());
+    for (size_t r = 0; r < ps.size(); ++r) {
+      size_t fs = finalStates[r];
+
+      if (dfa->states[fs]->refs == 0) {
+        dfa->c->unreachableMatchRowsPtr->emplace_back(r, ps[r]);
+      }
+    }
+  }
+
   // OK, this is a good DFA
   return rootS;
 }


### PR DESCRIPTION
Fix the breaking API introduced by https://github.com/morganstanley/hobbes/pull/408