### PR TITLE
Hobbes logs

### DIFF
--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -375,6 +375,9 @@ private:
   // the JIT engine that compiles our monotyped expressions
   jitcc *jit;
 
+  struct PerfTracer;
+  std::unique_ptr<PerfTracer> perfTracer;
+
 public:
   // compiler-local type structure caches for internal use
   std::unordered_map<MonoType *, MonoTypePtr> unappTyDefns;

--- a/include/hobbes/eval/jitcc.H
+++ b/include/hobbes/eval/jitcc.H
@@ -9,6 +9,7 @@
 #include <hobbes/util/llvm.H>
 #include <hobbes/eval/func.H>
 #include <hobbes/eval/ctype.H>
+#include <memory>
 
 #if LLVM_VERSION_MAJOR >= 11
 #include <llvm/IR/ValueHandle.h>
@@ -260,6 +261,9 @@ private:
 #if LLVM_VERSION_MAJOR >= 11
   std::unique_ptr<ORCJIT> orcjit;
 #endif
+
+  struct IrTracer;
+  std::unique_ptr<IrTracer> irTracer;
 };
 
 // shorthand for compilation over a sequence of expressions

--- a/lib/hobbes/eval/jitcc.C
+++ b/lib/hobbes/eval/jitcc.C
@@ -17,7 +17,7 @@
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/Compiler.h>
 #include <llvm/Support/Error.h>
-#include <llvm/Support/raw_os_ostream.h>
+#include <llvm/Support/FileSystem.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 
@@ -561,7 +561,7 @@ struct jitcc::IrTracer {
     if (name == nullptr) {
       return;
     }
-    out = std::make_unique<llvm::raw_fd_ostream>(name, ec);
+    out = std::make_unique<llvm::raw_fd_ostream>(name, ec, llvm::sys::fs::F_None);
     if (ec != std::errc()) {
       out = nullptr;
       return;


### PR DESCRIPTION
1. Another change is, when `HOBBES_IR_TRACE_FILE` is defined, **unoptimized** LLVM IR will be written to the specified file
3. when operating on _large_ variant or record, `unsweeten` might be slow. Adding some logs when both
    - `HOBBES_PERF_TRACE_FILE` log file path
    - `HOBBES_PERF_TRACE_THRESHOLD_IN_SECS` threshold for unsweetenning on **named** var

    are defined. Logs are in the format of

    ```
    HOBBES_PERF:rexec_data:BEGIN:3:show({a = |A = ()|::|A, B, C|, x = |X = ()|::|X, Y, Z|})
    HOBBES_PERF:rexec_data:2:{ a:|A, B, C|, x:|X, Y, Z| }
    HOBBES_PERF:rexec_data:3:|X, Y, Z|
    HOBBES_PERF:rexec_data:3:|A, B, C|
    HOBBES_PERF:rexec_data:END:9
    ```

    ```
    HOBBES_PERF:rexec_data:BEGIN: 3       :show({a = |A = ()|::|A, B, C|, x = |X = ()|::|X, Y, Z|})
    mark           name    mark   duration       expression
    ```

    ```
    HOBBES_PERF:rexec_data:3                :|X, Y, Z|
    mark           name    size_of_variant   variant
    ```

    ```
    HOBBES_PERF:rexec_data:END   :9
    mark           name    mark   new_expressions_generated_by_this_var
    ```
