### PR TITLE
add an env var to enable redirecting `print`'s output to file

### DIFF
--- a/include/hobbes/hobbes.H
+++ b/include/hobbes/hobbes.H
@@ -17,6 +17,8 @@
 
 namespace hobbes {
 
+constexpr const char* ENV_HOBBES_REDIRECT_PRINT_FILE = "HOBBES_REDIRECT_PRINT_FILE";
+
 // type aliases for common types
 DEFINE_TYPE_ALIAS_AS(timespanT, timespan, int64_t);
 

--- a/lib/hobbes/eval/funcdefs.C
+++ b/lib/hobbes/eval/funcdefs.C
@@ -8,9 +8,10 @@
 #include <hobbes/util/codec.H>
 #include <hobbes/util/stream.H>
 
-#include <stack>
-#include <iostream>
+#include <fstream>
 #include <iomanip>
+#include <iostream>
+#include <stack>
 #include <strings.h>
 #include <zlib.h>
 
@@ -458,7 +459,13 @@ const array<char>* releaseStdout() {
 }
 
 void putStr(array<char>* x) {
-  std::cout.write(x->data, x->size);
+  const char* redirectFilename = std::getenv(ENV_HOBBES_REDIRECT_PRINT_FILE);
+  if (redirectFilename == nullptr) {
+    std::cout.write(x->data, x->size);
+  } else {
+    std::ofstream ofs(redirectFilename, std::ios_base::app);
+    ofs.write(x->data, x->size);
+  }
 }
 
 size_t cstrlen(char* x) {

--- a/test/Prelude.C
+++ b/test/Prelude.C
@@ -1,7 +1,9 @@
+#include <hobbes/hobbes.H>
 
 #include <exception>
-#include <hobbes/hobbes.H>
+#include <fstream>
 #include <stdexcept>
+
 #include "test.H"
 
 using namespace hobbes;
@@ -149,4 +151,18 @@ TEST(Prelude, Long) {
   EXPECT_EXCEPTION_MSG(c().compileFn<long()>("-9223372036854775808L")(), std::exception, "literal 9223372036854775808 is not supported");
   // LONG_MIN - 1
   EXPECT_EXCEPTION_MSG(c().compileFn<long()>("-9223372036854775809L")(), std::exception, "literal 9223372036854775809 is not supported");
+}
+
+TEST(Prelude, RedirectPrint) {
+  constexpr const char* filename = ".happ.out";
+  ::setenv(ENV_HOBBES_REDIRECT_PRINT_FILE, filename, /*replace*/1);
+  c().compileFn<void()>("print({a=1,b=2})")();
+  ::unsetenv(ENV_HOBBES_REDIRECT_PRINT_FILE);
+  {
+    std::ifstream ifs(filename);
+    std::ostringstream oss;
+    oss << ifs.rdbuf();
+    EXPECT_EQ(oss.str(), "{a=1, b=2}");
+  }
+  ::unlink(filename);
 }


### PR DESCRIPTION
setting `HOBBES_REDIRECT_PRINT_FILE` to redirect `print`'s output to specified file