### PR TITLE
fix hog server listens only on localhost

### DIFF
--- a/include/hobbes/net.H
+++ b/include/hobbes/net.H
@@ -160,9 +160,16 @@ inline addrinfo* lookupAddrInfo(const std::string& host, const std::string& port
   memset(&h, 0, sizeof(h));
   h.ai_family   = AF_UNSPEC;
   h.ai_socktype = SOCK_STREAM;
+  const bool isServer = host.empty();
+  const char* hostname = isServer ? nullptr : host.c_str();
+  const char* service = port.empty() ? nullptr : port.c_str();
+  assert(!(hostname == nullptr && service == nullptr));
+  if (isServer) {
+    h.ai_flags = AI_PASSIVE;
+  }
 
   struct addrinfo* addrs = nullptr;
-  switch (getaddrinfo(host.empty()? nullptr : host.c_str(), port.empty() ? nullptr : port.c_str(), &h, &addrs)) {
+  switch (getaddrinfo(hostname, service, &h, &addrs)) {
   case 0:              return addrs;
   case EAI_ADDRFAMILY: throw std::runtime_error("Cannot make socket connection to " + host + ":" + port);
   case EAI_AGAIN:      throw std::runtime_error(host + ":" + port + " is temporarily unavailable");


### PR DESCRIPTION
```
       If the AI_PASSIVE flag is specified in hints.ai_flags, and node
       is NULL, then the returned socket addresses will be suitable for
       bind(2)ing a socket that will accept(2) connections.  The
       returned socket address will contain the "wildcard address"
       (INADDR_ANY for IPv4 addresses, IN6ADDR_ANY_INIT for IPv6
       address).  The wildcard address is used by applications
       (typically servers) that intend to accept connections on any of
       the host's network addresses.  If node is not NULL, then the
       AI_PASSIVE flag is ignored.

       If the AI_PASSIVE flag is not set in hints.ai_flags, then the
       returned socket addresses will be suitable for use with
       connect(2), sendto(2), or sendmsg(2).  If node is NULL, then the
       network address will be set to the loopback interface address
       (INADDR_LOOPBACK for IPv4 addresses, IN6ADDR_LOOPBACK_INIT for
       IPv6 address); this is used by applications that intend to
       communicate with peers running on the same host.
```
https://man7.org/linux/man-pages/man3/getaddrinfo.3.html

without `AI_PASSIVE`, hog server always listens on localhost