### PR TITLE
with a large (>500) match table, variant might cause "not a primitive match table" error

### DIFF
--- a/lib/hobbes/lang/pat/dfa.C
+++ b/lib/hobbes/lang/pat/dfa.C
@@ -90,6 +90,9 @@ MStatePtr makeSwitch(const MDFA* dfa, const std::string& switchVar, const Switch
     if (jmps.empty()) {
       return dfa->states[defState];
     } else if (isUnit(jmps[0].first->primType())) {
+      if (dfa->inPrimSel) {
+        return dfa->states[jmps[0].second];
+      }
       return actAndThen(assume(var(switchVar, dfa->rootLA), primty("unit"), dfa->rootLA), jmps[0].second);
     } else {
       return MStatePtr(new SwitchVal(switchVar, jmps, defState));

--- a/test/Matching.C
+++ b/test/Matching.C
@@ -453,3 +453,17 @@ TEST(Matching, noRaceInterpMatch) {
   EXPECT_EQ(wrongMatches.load(), size_t(0));
   c().buildInterpretedMatches(false);
 }
+
+TEST(Matching, isPrimSelectionWithVariant) {
+  std::ostringstream rows;
+  rows << "(\\a b.match a b with\n";
+  rows << "| |Close| _ -> 1\n";
+  for (size_t i = 0; i < 499; ++i) {
+    rows << "| _ " << i << " -> " << i+2 << "\n";
+  }
+  rows << "| _ _ -> -1\n";
+  rows << ")(|Open|::|Open, Close|, 9)";
+  auto f = c().compileFn<int()>(rows.str());
+  EXPECT_EQ(f(), 11);
+}
+


### PR DESCRIPTION
if `isPrimSelection` is on, and pivoting on a variant like `|Close|`, it creates a `LoadVars` state at https://github.com/mo-xiaoming/hobbes/blob/main/lib/hobbes/lang/pat/dfa.C#L93, but `LoadVars` cannot be handled in a prim table https://github.com/mo-xiaoming/hobbes/blob/main/lib/hobbes/lang/pat/dfa.C#L1471