### PR TITLE
array.H: include cstdint to fix llvm 12+ build

### DIFF
--- a/include/hobbes/util/array.H
+++ b/include/hobbes/util/array.H
@@ -3,6 +3,7 @@
 #define HOBBES_UTIL_ARRAY_HPP_INCLUDED
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <map>


### PR DESCRIPTION
include cstdint in arrah.H to fix build errors when compiling with llvm-12+.
```console
include/hobbes/util/array.H:325:22: error: unknown type name 'uint8_t'
```
