### PR TITLE
Retry the nix builds past GitHub's rate limit

### DIFF
--- a/.github/scripts/nix-build-retry.sh
+++ b/.github/scripts/nix-build-retry.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Build a flake attribute, retrying past GitHub's secondary rate limit.
+#
+# Nix resolves the github: flake inputs (flake-utils, nixpkgs) by downloading a
+# tarball from api.github.com. When the build matrices start, 23 jobs fetch both
+# inputs within a minute or two, and GitHub answers some of them with
+#
+#     HTTP error 429 ... 429: Too Many Requests
+#     For more on scraping GitHub and how it may affect your rights, ...
+#
+# That is the secondary (anti-abuse) limit rather than the documented hourly
+# quota: it is applied per source address, and hosted runners share addresses.
+# A token does not lift it, and install-nix-action already configures one from
+# GITHUB_TOKEN regardless. It does clear on its own after about a minute.
+#
+# Nix retries the download itself, but gives up after roughly 45 seconds --
+# just short of the reset -- which is why re-running the job by hand works.
+# Waiting longer between attempts is what actually gets past it.
+#
+# Only that failure is retried. A compile error or a failing test is not going
+# to build on the second attempt, and retrying it would just delay the report.
+set -euo pipefail
+
+attr=${1:?usage: nix-build-retry.sh <flake-attr>}
+attempts=${NIX_BUILD_ATTEMPTS:-3}
+delay=${NIX_BUILD_RETRY_DELAY:-90}
+
+log=$(mktemp)
+trap 'rm -f "$log"' EXIT
+
+for attempt in $(seq 1 "$attempts"); do
+  if nix build "$attr" 2>&1 | tee "$log"; then
+    exit 0
+  fi
+
+  if ! grep -qE 'HTTP error 429|error: unable to download' "$log"; then
+    echo "nix build $attr failed, and not on a GitHub rate limit -- not retrying" >&2
+    exit 1
+  fi
+
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "nix build $attr hit GitHub's rate limit (attempt $attempt/$attempts); retrying in ${delay}s"
+    sleep "$delay"
+  fi
+done
+
+echo "nix build $attr still rate limited after $attempts attempts" >&2
+exit 1

--- a/.github/scripts/nix-build-retry.sh
+++ b/.github/scripts/nix-build-retry.sh
@@ -34,7 +34,11 @@ for attempt in $(seq 1 "$attempts"); do
     exit 0
   fi
 
-  if ! grep -qE 'HTTP error 429|error: unable to download' "$log"; then
+  # Match the rate limit itself, not download failures in general: a 404 from a
+  # bad flake ref is a download failure too, and it will still be a 404 three
+  # attempts and two waits later. Both spellings below come from the same 429 --
+  # nix prints the status line, then quotes GitHub's body.
+  if ! grep -qE 'HTTP error 429|429: Too Many Requests' "$log"; then
     echo "nix build $attr failed, and not on a GitHub rate limit -- not retrying" >&2
     exit 1
   fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
   linux-clang-ASanAndUBSan-build:
     runs-on: ${{matrix.os}}
     strategy:
+      # One pairing failing says nothing about the rest, as python-compat below
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04]
         clang: [16, 18, 20, 21]
@@ -25,7 +27,7 @@ jobs:
           python-version: '3.10'
       - name: nix build hobbesPackages/clang-${{ matrix.clang }}-ASanAndUBSan/hobbes
         run: |
-          nix build .#hobbesPackages/clang-${{ matrix.clang }}-ASanAndUBSan/hobbes
+          .github/scripts/nix-build-retry.sh .#hobbesPackages/clang-${{ matrix.clang }}-ASanAndUBSan/hobbes
       - name: nix log hobbesPackages/clang-${{ matrix.clang }}-ASanAndUBSan/hobbes
         if: ${{ always() }}
         run: |
@@ -39,6 +41,8 @@ jobs:
   linux-clang-build:
     runs-on: ${{matrix.os}}
     strategy:
+      # One pairing failing says nothing about the rest, as python-compat below
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04]
         clang: [16, 18, 20, 21]
@@ -56,7 +60,7 @@ jobs:
           python-version: '3.10'
       - name: nix build hobbesPackages/clang-${{ matrix.clang }}/hobbes
         run: |
-          nix build .#hobbesPackages/clang-${{ matrix.clang }}/hobbes
+          .github/scripts/nix-build-retry.sh .#hobbesPackages/clang-${{ matrix.clang }}/hobbes
       - name: Rosetta Code examples
         run: |
           bash examples/rosetta/run_tests.sh result/bin/hi
@@ -73,6 +77,8 @@ jobs:
   linux-gcc-build:
     runs-on: ${{matrix.os}}
     strategy:
+      # One pairing failing says nothing about the rest, as python-compat below
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04]
         gcc: [13, 14, 15]
@@ -91,7 +97,7 @@ jobs:
           python-version: '3.10'
       - name: nix build hobbesPackages/gcc-${{ matrix.gcc }}/llvm-${{ matrix.llvm }}/hobbes
         run: |
-          nix build .#hobbesPackages/gcc-${{ matrix.gcc }}/llvm-${{ matrix.llvm }}/hobbes
+          .github/scripts/nix-build-retry.sh .#hobbesPackages/gcc-${{ matrix.gcc }}/llvm-${{ matrix.llvm }}/hobbes
       - name: nix log hobbesPackages/gcc-${{ matrix.gcc }}/llvm-${{ matrix.llvm }}/hobbes
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
The nix jobs fail intermittently while resolving flake inputs. From
[`linux-gcc-build (ubuntu-24.04, 14, 16)`](https://github.com/morganstanley/hobbes/actions/runs/32035833494/job/95405925760):

```
warning: unable to download 'https://api.github.com/repos/numtide/flake-utils/tarball/2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28': HTTP error 429
error: Failed to open archive (Source threw exception: error: unable to download ... HTTP error 429
      429: Too Many Requests
      For more on scraping GitHub and how it may affect your rights, please review our Terms of Service)
```

## Why it happens

Nix resolves a `github:` flake ref by downloading a tarball from
`api.github.com`. `build.yml` has 23 nix jobs — `linux-clang-ASanAndUBSan-build`
(4), `linux-clang-build` (4) and `linux-gcc-build` (15) — and each resolves both
`flake-utils` and `nixpkgs`. A push therefore asks for those inputs some **46
times in the couple of minutes** the matrices take to start.

The *"scraping"* wording in the response body is the important part: this is
GitHub's **secondary, anti-abuse limit**, not the documented hourly quota. Two
consequences:

- It is keyed on the **source address**, which hosted runners share, so it is
  not really our budget to manage.
- **Authenticating does not lift it.** Worth stating plainly because it is the
  obvious thing to reach for: `install-nix-action` already writes
  `access-tokens = github.com=$GITHUB_TOKEN` whether or not a token is passed to
  it ([`install-nix.sh#L48-L52`](https://github.com/cachix/install-nix-action/blob/630ae543ea3a38a9a4166f03376c02c50f408342/install-nix.sh#L48-L52),
  with `action.yml` supplying `GITHUB_TOKEN: ${{ github.token }}`). These
  requests were already authenticated when they were refused.

It does clear by itself after about a minute.

## Why retrying is the fix

Nix retries the download on its own, but not for long enough. In the failure
above the attempts run `13:35:10 → 13:35:18 → 13:35:23 → 13:35:44` and it gives
up at `13:35:54` — roughly **45 seconds, just short of the reset**. That is
precisely why re-running the job by hand works, and it is the whole of this
change: wait longer between attempts.

`.github/scripts/nix-build-retry.sh` wraps `nix build` with 3 attempts and 90s
between them (`NIX_BUILD_ATTEMPTS` / `NIX_BUILD_RETRY_DELAY` to tune).

**Only the rate limit is retried**, matched on the 429 in the output. A compile
error or failing test will not succeed on a second attempt and retrying would
only delay the report, so **time to red for a genuine break is unchanged**.

## Also: `fail-fast: false`

On the three nix matrices, as `python-compat` already does. The run above turned
one rate-limited job into fifteen red ones, and a fifteen-job re-run to establish
that fourteen of them were fine. The effect is visible in this PR's own history:
an earlier revision failed with 3 red and 31 green rather than taking the whole
matrix down.

## Testing

The retry logic is exercised against a stubbed `nix` for the four cases that
matter:

| case | nix invocations | exit |
|---|---|---|
| rate-limited once, then succeeds | 2 | 0 |
| real compile error | **1** (no retry) | 1 |
| rate-limited on every attempt | 3 | 1 |
| succeeds first time | 1 | 0 |

`build.yml` still parses, all three nix jobs carry the wrapper and
`fail-fast: false`, and the six non-nix jobs are untouched.

Note on what CI here can and cannot show: a green run does **not** prove the fix
works, since these jobs pass anyway whenever the shared limit happens to be
healthy. What would demonstrate it is a run where the log shows a 429 followed by
a successful retry.

## Not included

A binary cache (`cachix-action`, or a prefetch job with `actions/cache` over
`~/.cache/nix`) would cut those ~46 fetches to ~2 and save build minutes, which
attacks the cause rather than the symptom. It is a larger change with its own
trade-offs; happy to follow up if wanted.
