### PR TITLE
Reject out-of-range type variable indices when decoding

### DIFF
--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -11,6 +11,7 @@
 #include <hobbes/util/codec.H>
 #include <hobbes/util/perf.H>
 #include <hobbes/util/str.H>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
@@ -639,6 +640,15 @@ const std::string& TVar::name() const { return this->nm; }
 void TVar::show(std::ostream& out) const { out << this->nm; }
 
 MonoTypePtr TGen::make(int x) {
+  // a TGen is an index into the type variables quantified by the enclosing
+  // polytype, so it is always non-negative, and the constructor derives a
+  // count of 'x + 1' from it -- that increment overflows at INT_MAX. Reject
+  // both out-of-domain cases here rather than in the decoder alone, since
+  // every path that can carry an attacker-supplied index (the binary type
+  // decoder in particular) funnels through this constructor.
+  if (x < 0 || x == std::numeric_limits<int>::max()) {
+    throw std::runtime_error("Invalid type variable index: " + str::from(x));
+  }
   return makeType<TGenMem, TGen>(x);
 }
 

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -68,6 +68,30 @@ TEST(TypeInf, DecodeRejectsTruncatedInput) {
   EXPECT_TRUE(threw);
 }
 
+TEST(TypeInf, DecodeRejectsOutOfRangeTGen) {
+  // a TGen carries an index into the type variables quantified by the enclosing
+  // polytype, and the type constructor derives a count of 'index + 1' from it.
+  // A decoded index of INT_MAX overflows that increment (signed overflow is
+  // undefined behavior), and a negative index is meaningless, so both must be
+  // rejected rather than constructed.
+  auto encodeTGenIndex = [](int i) {
+    std::vector<unsigned char> bs(sizeof(int) + sizeof(int));
+    int tag = TGen::type_case_id;
+    memcpy(&bs[0], &tag, sizeof(tag));
+    memcpy(&bs[sizeof(int)], &i, sizeof(i));
+    return bs;
+  };
+
+  // a well-formed index still round-trips
+  EXPECT_TRUE(show(decode(encodeTGenIndex(3))) == show(TGen::make(3)));
+
+  for (int i : {std::numeric_limits<int>::max(), std::numeric_limits<int>::min(), -1}) {
+    bool threw = false;
+    try { decode(encodeTGenIndex(i)); } catch (const std::exception&) { threw = true; }
+    EXPECT_TRUE(threw);
+  }
+}
+
 TEST(TypeInf, CodecRejectsInvalidBoolValue) {
   // the stream codec decodes data that can arrive from an untrusted peer;
   // loading any byte other than 0 or 1 into a bool is undefined behavior, so


### PR DESCRIPTION
Fixes a signed integer overflow that OSS-Fuzz found in the binary type decoder
([issue 549526825](https://issues.oss-fuzz.com/issues/549526825), harness
`fuzz-type-decode`, job `libfuzzer_ubsan_hobbes`).

## The bug

A `TGen` carries an index into the type variables quantified by the enclosing
polytype, and its constructor derives a count of `index + 1` from it:

```cpp
TGen::TGen(int x) : x(x) {
  this->tgenCount = x + 1;   // lib/hobbes/lang/type.C:646
}
```

`decodeTGen` reads that index straight out of its input buffer with no range
check. Per [SECURITY.md](SECURITY.md) that buffer is untrusted — it can come
from a structured data file or from a network peer before the peer would be
trusted — so an index of `INT_MAX` reaches the increment and overflows it.

The whole reproducer is eight bytes:

```
03 00 00 00 ff ff ff 7f    # TGen::type_case_id, then INT_MAX
```

which a UBSan build aborts on:

```
lib/hobbes/lang/type.C:646:23: runtime error: signed integer overflow:
  2147483647 + 1 cannot be represented in type 'int'
    #0  hobbes::TGen::TGen(int) type.C:646
    #1  ...makeType<unique_refc_map<TGen const, int>, TGen, int>(int const&)::'lambda'
    #9  hobbes::unique_refc_map<hobbes::TGen const, int>::get(...) ptr.H:27
    #11 hobbes::TGen::make(int) type.C:642
    #12 hobbes::decodeTGen(...) type.C:2614
    #13 hobbes::decodeFrom(...) type.C:2726
```

## The fix

Validate the index in `TGen::make` rather than in `decodeTGen` alone, so the
one check covers every path into the constructor.

Negative indices are rejected on the same grounds: they are equally
meaningless as a position in the quantifier list, and no caller in the tree
produces one — `tgens()` counts up from zero, and the remaining call sites in
`db/bindings.C`, `db/signals.C`, and `preds/subtype/obj.C` pass small
non-negative values.

## Verification

Built `fuzz-type-decode` with UBSan (`-fsanitize=undefined,signed-integer-overflow
-fno-sanitize-recover=all`), matching the job that reported it:

* before the fix, the eight-byte input above reproduces the trace shown
* after the fix, it runs clean, and the decoder rejects the input with an
  exception like every other malformed encoding
* full `hobbes-test` passes (20/20 groups)

`TypeInf/DecodeRejectsOutOfRangeTGen` covers the regression, decoding crafted
`INT_MAX`, `INT_MIN`, and `-1` indices alongside a well-formed one that must
still round-trip.

## Age

`git log -L 646,646:lib/hobbes/lang/type.C` puts the arithmetic in the initial
public commit (f81d016, 2017-06-16), so this is an old bug rather than a recent
regression.