### PR TITLE
Link the OSS-Fuzz build status now that it runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # hobbes
 
 ![Lifecycle Active](https://img.shields.io/badge/Lifecycle-Active-brightgreen)
+[![OSS-Fuzz](https://oss-fuzz-build-logs.storage.googleapis.com/badges/hobbes.svg)](https://issues.oss-fuzz.com/issues?q=project:hobbes)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/morganstanley/hobbes/badge)](https://scorecard.dev/viewer/?uri=github.com/morganstanley/hobbes)
 
 a language, embedded compiler, and runtime for efficient dynamic expression evaluation, data storage and analysis
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -120,16 +120,24 @@ access, an RPC peer executing code) is not a vulnerability.
 
 ## OSS-Fuzz
 
-The same harnesses are meant to run continuously on Google's OSS-Fuzz. That
-needs a submission to the [OSS-Fuzz
-repository](https://github.com/google/oss-fuzz) which has not been accepted
-yet, so nothing runs there until it is; ClusterFuzzLite below is what covers
-pull requests in the meantime. What gets submitted is a `projects/hobbes/`
-directory there — a `project.yaml`, a
-`Dockerfile` that installs LLVM and clones this repository, and a `build.sh`
-that is a one-line wrapper around `fuzz/oss-fuzz-build.sh` here. Keeping the
-real build script in this tree means harness changes and build changes land in
-the same commit.
+The same harnesses run continuously on Google's
+[OSS-Fuzz](https://github.com/google/oss-fuzz), which accepted the project in
+August 2026 and builds `main` daily; ClusterFuzzLite below is what covers pull
+requests, before a change lands. The submission is the `projects/hobbes/`
+directory there — a `project.yaml`, a `Dockerfile` that installs LLVM and
+clones this repository, and a `build.sh` that is a one-line wrapper around
+`fuzz/oss-fuzz-build.sh` here. Keeping the real build script in this tree
+means harness changes and build changes land in the same commit.
+
+Three places show what it is doing: the build badge at the top of the
+repository `README.md`, the [project
+profile](https://introspector.oss-fuzz.com/project-profile?project=hobbes),
+which links the daily coverage report, and the [issue
+tracker](https://issues.oss-fuzz.com/issues?q=project:hobbes). The badge
+covers the coverage and introspector builds as well as the fuzzing one, so it
+can go yellow over a report that failed to generate while fuzzing itself is
+fine. Findings are restricted until they are fixed or the disclosure deadline
+passes, so the tracker looks empty to anyone who is not a project contact.
 
 `oss-fuzz-build.sh` differs from a local fuzzing build in three ways worth
 knowing about:
@@ -166,9 +174,9 @@ vulnerability.
 
 `.clusterfuzzlite/` and `.github/workflows/clusterfuzzlite.yml` run the same
 harnesses on pull requests that touch code they cover, for a few minutes each,
-against the change itself rather than against `main`. Unlike OSS-Fuzz this
-needs no registration with any service, so it applies to every pull request
-regardless of how the OSS-Fuzz submission is received.
+against the change itself rather than against `main`. That is the half
+OSS-Fuzz cannot do: it builds what has already been merged, so a crash it
+finds is a crash that already shipped to `main`.
 
 The image mirrors the OSS-Fuzz one and the build script is shared; the only
 difference is that the source is copied in from the checkout being tested


### PR DESCRIPTION
OSS-Fuzz accepted `projects/hobbes` and has been building `main` daily since 2026-08-19, so `fuzz/README.md` is now wrong where it says the submission is pending and that nothing runs there.

* Add the OSS-Fuzz build badge to the top-level `README.md`, linked to the project's issue tracker. It is green as of the 2026-08-20 build.
* Add the OpenSSF Scorecard badge. The workflow from #516 has been publishing to the OpenSSF API since 2026-08-15 — first publish was the condition for adding the badge — and the project currently scores 9/10.
* Rewrite the `## OSS-Fuzz` section around the live setup: the badge, the [project profile](https://introspector.oss-fuzz.com/project-profile?project=hobbes) that links the daily coverage report, and the issue tracker.

One behaviour worth having written down, because it looks alarming and is not: that badge aggregates the coverage and introspector builds along with the fuzzing one. The first coverage build failed — `Failed to unpack the corpus for fuzz-parse-expr` — because corpus backups do not exist until the pruning task has run once, so the badge showed "coverage failing" in yellow for a day while fuzzing itself was fine. It cleared on the next daily run without any change here.

The ClusterFuzzLite paragraph said it applies "regardless of how the OSS-Fuzz submission is received", which is also stale; it now states the actual split, which is that ClusterFuzzLite tests a change before it lands and OSS-Fuzz builds what has already merged.

Documentation only — no code, build or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)