### PR TITLE
Reject non-primitive switch selectors when decoding expressions 

### DIFF
--- a/lib/hobbes/lang/expr.C
+++ b/lib/hobbes/lang/expr.C
@@ -5,6 +5,7 @@
 #include <hobbes/util/time.H>
 #include <hobbes/util/codec.H>
 #include <hobbes/util/stream.H>
+#include <memory>
 #include <sstream>
 
 namespace hobbes {
@@ -720,7 +721,7 @@ Expr* Switch::clone() const {
   ExprPtr cdef = this->def ? ExprPtr(this->def->clone()) : ExprPtr();
   Bindings cbs;
   for (const auto& b : this->bs) {
-    cbs.push_back(Binding(PrimitivePtr(reinterpret_cast<Primitive*>(b.value->clone())), ExprPtr(b.exp->clone())));
+    cbs.push_back(Binding(PrimitivePtr(static_cast<Primitive*>(b.value->clone())), ExprPtr(b.exp->clone())));
   }
   return new Switch(ExprPtr(this->v->clone()), cbs, cdef, la());
 }
@@ -1648,11 +1649,27 @@ struct encodeExprF : public switchExpr<UnitV> {
 };
 
 void encode(const PrimitivePtr& p, std::ostream& out) {
-  encode(reinterpret_cast<const ExprPtr&>(p), out);
+  encode(std::static_pointer_cast<Expr>(p), out);
 }
 
 void decode(PrimitivePtr* p, std::istream& in) {
-  decode(reinterpret_cast<ExprPtr*>(p), in);
+  // A primitive constant is encoded as an ordinary expression, so decoding one
+  // means decoding an arbitrary expression and confirming that it really is a
+  // primitive. Reinterpreting the pointer instead skipped that check, and the
+  // encoded form can come from an untrusted peer: a switch selector encoded as,
+  // say, a nested switch yielded a shared_ptr<Primitive> aimed at an object of
+  // an unrelated type, and the first virtual call on it -- the duplicate-selector
+  // check in Switch's own constructor -- dispatched through the wrong vtable.
+  ExprPtr e;
+  decode(&e, in);
+
+  PrimitivePtr r = std::dynamic_pointer_cast<Primitive>(e);
+  if (!r) {
+    throw std::runtime_error(
+      "Expected a primitive constant in encoded expression, but read expression type: " +
+      str::from(e->case_id()));
+  }
+  *p = r;
 }
 
 void encode(const ExprPtr& e, std::ostream& out) {

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -179,3 +179,93 @@ TEST(TypeInf, CodecRejectsOversizedLengthOnNonSeekableStream) {
   decode(&s, gin);
   EXPECT_TRUE(s == "elephant");
 }
+
+TEST(TypeInf, DecodeRejectsNonPrimitiveSwitchSelector) {
+  // A switch selector is encoded as an ordinary expression but is held as a
+  // PrimitivePtr once decoded, and nothing in the encoding obliges a peer to
+  // put a primitive constant there. Reinterpreting the decoded pointer skipped
+  // the check, so a selector encoded as some other expression produced a
+  // shared_ptr<Primitive> aimed at an unrelated object, and the first virtual
+  // call on it -- the duplicate-selector check in Switch's own constructor --
+  // dispatched through the wrong vtable (oss-fuzz 549508407, fuzz-type-decode,
+  // reached from the RPC path through TExpr).
+  auto unitExpr = [](std::ostream& out) {
+    encode(Unit::type_case_id, out);
+    encode(false, out);                                // no annotated type
+  };
+  auto switchWithSelector = [&](const std::function<void(std::ostream&)>& sel) {
+    std::ostringstream ss;
+    encode(Switch::type_case_id, ss);
+    unitExpr(ss);                                      // scrutinee: ()
+    encode(static_cast<size_t>(1), ss);                // one binding...
+    sel(ss);                                           // ...with this selector
+    unitExpr(ss);                                      // ...and this body
+    encode(false, ss);                                 // no default case
+    encode(false, ss);                                 // no annotated type
+    const std::string s = ss.str();
+    return std::vector<uint8_t>(s.begin(), s.end());
+  };
+
+  // a variable, and a nested switch (the shape the fuzzer found): neither is a
+  // primitive constant, so both must be rejected
+  std::vector<std::vector<uint8_t>> hostile;
+  hostile.push_back(switchWithSelector([](std::ostream& out) {
+    encode(Var::type_case_id, out);
+    encode(std::string("x"), out);
+    encode(false, out);
+  }));
+  hostile.push_back(switchWithSelector([&](std::ostream& out) {
+    encode(Switch::type_case_id, out);
+    unitExpr(out);                                     // scrutinee: ()
+    encode(static_cast<size_t>(0), out);               // no bindings...
+    encode(true, out);                                 // ...but a default case,
+    unitExpr(out);                                     // so this switch is valid
+    encode(false, out);
+  }));
+
+  for (const auto& enc : hostile) {
+    // rejected where the expression is decoded ...
+    std::string msg;
+    try {
+      ExprPtr e;
+      decode(enc, &e);
+    } catch (const std::exception& ex) {
+      msg = ex.what();
+    }
+    EXPECT_TRUE(msg.find("primitive constant") != std::string::npos);
+
+    // ... and so also on the type-decoder surface the fuzzer drives, where the
+    // same bytes arrive wrapped in a type-level expression
+    std::vector<unsigned char> tenc;
+    auto append = [&](const void* p, size_t n) {
+      const auto* b = static_cast<const unsigned char*>(p);
+      tenc.insert(tenc.end(), b, b + n);
+    };
+    const int tag = TExpr::type_case_id;
+    const size_t len = enc.size();
+    append(&tag, sizeof(tag));
+    append(&len, sizeof(len));
+    tenc.insert(tenc.end(), enc.begin(), enc.end());
+
+    msg.clear();
+    try {
+      decode(tenc);
+    } catch (const std::exception& ex) {
+      msg = ex.what();
+    }
+    EXPECT_TRUE(msg.find("primitive constant") != std::string::npos);
+  }
+
+  // a well-formed switch still round-trips over the same path
+  Switch::Bindings bs;
+  bs.push_back(Switch::Binding(
+    PrimitivePtr(new Unit(LexicalAnnotation::null())),
+    ExprPtr(new Unit(LexicalAnnotation::null()))));
+  ExprPtr sw(new Switch(ExprPtr(new Unit(LexicalAnnotation::null())), bs, LexicalAnnotation::null()));
+
+  std::vector<uint8_t> good;
+  encode(sw, &good);
+  ExprPtr rt;
+  decode(good, &rt);
+  EXPECT_TRUE(show(rt) == show(sw));
+}


### PR DESCRIPTION
decode(PrimitivePtr*) reinterpret_cast its out-parameter to an ExprPtr* and decoded whatever expression the input described. Nothing in the encoding obliges a peer to put a primitive constant in selector position, so a switch whose selector was encoded as some other expression produced a shared_ptr<Primitive> aimed at an object of an unrelated type. The first virtual call on it -- the duplicate-selector check that Switch's own constructor runs through std::set<PrimitivePtr, PrimPtrLT> -- then dispatched through the wrong vtable.

The path is reachable from unauthenticated input: ipc/net.C decodes a peer's type descriptions before accepting any expression, and a type-level expression (TExpr) carries an encoded expression along with it. That is how OSS-Fuzz 549508407 reached it from fuzz-type-decode, reported as a bad-cast to hobbes::Primitive from hobbes::Switch. The bug is as old as the expression codec, not a recent regression.

Decode an expression and check what came back, throwing if it is not a primitive constant. The two other unchecked casts around the same values go with it: encoding now goes through static_pointer_cast, and Switch::clone downcasts its own clones with static_cast rather than reinterpret_cast.