### PR TITLE
Decode switch selectors as primitives, not as any expression

### DIFF
--- a/lib/hobbes/lang/expr.C
+++ b/lib/hobbes/lang/expr.C
@@ -5,6 +5,7 @@
 #include <hobbes/util/time.H>
 #include <hobbes/util/codec.H>
 #include <hobbes/util/stream.H>
+#include <memory>
 #include <sstream>
 
 namespace hobbes {
@@ -1650,7 +1651,7 @@ struct encodeExprF : public switchExpr<UnitV> {
 };
 
 void encode(const PrimitivePtr& p, std::ostream& out) {
-  encode(ExprPtr(p), out);
+  encode(std::static_pointer_cast<Expr>(p), out);
 }
 
 // A primitive is encoded as a plain expression, so what comes back is whatever

--- a/lib/hobbes/lang/expr.C
+++ b/lib/hobbes/lang/expr.C
@@ -720,7 +720,9 @@ Expr* Switch::clone() const {
   ExprPtr cdef = this->def ? ExprPtr(this->def->clone()) : ExprPtr();
   Bindings cbs;
   for (const auto& b : this->bs) {
-    cbs.push_back(Binding(PrimitivePtr(reinterpret_cast<Primitive*>(b.value->clone())), ExprPtr(b.exp->clone())));
+    // a downcast, not a reinterpretation: clone() is declared on Expr but the
+    // object really is a Primitive, so let the compiler adjust the pointer
+    cbs.push_back(Binding(PrimitivePtr(static_cast<Primitive*>(b.value->clone())), ExprPtr(b.exp->clone())));
   }
   return new Switch(ExprPtr(this->v->clone()), cbs, cdef, la());
 }
@@ -1648,11 +1650,26 @@ struct encodeExprF : public switchExpr<UnitV> {
 };
 
 void encode(const PrimitivePtr& p, std::ostream& out) {
-  encode(reinterpret_cast<const ExprPtr&>(p), out);
+  encode(ExprPtr(p), out);
 }
 
+// A primitive is encoded as a plain expression, so what comes back is whatever
+// expression the input names -- it is not necessarily a Primitive. Decoding a
+// case id into a PrimitivePtr must therefore be a checked conversion: these
+// bytes can come from a file or an untrusted peer, and a Switch binding holds
+// its selector as a Primitive and calls Primitive's virtuals on it. Casting the
+// pointer unchecked would dispatch those calls through the vtable of an
+// unrelated Expr subclass and read past the end of the object.
 void decode(PrimitivePtr* p, std::istream& in) {
-  decode(reinterpret_cast<ExprPtr*>(p), in);
+  ExprPtr e;
+  decode(&e, in);
+
+  PrimitivePtr r = std::dynamic_pointer_cast<Primitive>(e);
+  if (!r) {
+    throw std::runtime_error(
+      "Expected a primitive constant in encoded expression, but found: " + show(e));
+  }
+  *p = r;
 }
 
 void encode(const ExprPtr& e, std::ostream& out) {

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -184,66 +184,104 @@ TEST(TypeInf, DecodeRejectsNonPrimitiveSwitchSelector) {
   // A switch binding holds its selector as a Primitive, and the switch
   // constructor calls Primitive's virtuals on it (operator< via PrimPtrLT, to
   // reject duplicate selectors). The selector is encoded as an ordinary
-  // expression, though, so a hostile buffer can name any expression case there
-  // -- a record, say. Converting that pointer unchecked dispatched Primitive's
-  // virtuals through the vtable of an unrelated Expr subclass and read past the
-  // end of the object (OSS-Fuzz 549385905, reached through hobbes::decode via
-  // an encoded TExpr type).
-  auto expr = [](int cid) {
-    std::ostringstream e;
-    encode(cid, e);
-    return e.str();
+  // expression, though, and nothing in the encoding obliges a peer to put a
+  // primitive constant there. Converting the decoded pointer unchecked
+  // dispatched those virtuals through the vtable of an unrelated Expr subclass.
+  //
+  // Two OSS-Fuzz reports of the same defect, differing only in what the
+  // selector named and therefore in which sanitizer caught it first:
+  //   549385905 -- a record selector, reaching MkRecord::operator==, which read
+  //                its std::vector member past the end of the object (ASan
+  //                heap-buffer-overflow)
+  //   549508407 -- a variable and a nested switch (UBSan bad-cast)
+  // Both were found by fuzz-type-decode, which reaches the expression decoder
+  // through a type-level expression.
+  auto unitExpr = [](std::ostream& out) {
+    encode(Unit::type_case_id, out);
+    encode(false, out);                                // no annotated type
   };
-  auto untyped = [](std::ostringstream& out) { encode(false, out); };
+  auto switchWithSelectors =
+    [&](const std::vector<std::function<void(std::ostream&)>>& sels) {
+      std::ostringstream ss;
+      encode(Switch::type_case_id, ss);
+      unitExpr(ss);                                    // scrutinee: ()
+      encode(static_cast<size_t>(sels.size()), ss);
+      for (const auto& sel : sels) {
+        sel(ss);                                       // the selector...
+        unitExpr(ss);                                  // ...and its body
+      }
+      encode(false, ss);                               // no default case
+      encode(false, ss);                               // no annotated type
+      const std::string s = ss.str();
+      return std::vector<uint8_t>(s.begin(), s.end());
+    };
 
-  std::ostringstream out;
-  encode(Switch::type_case_id, out);
+  // a record, a variable, and a nested switch: none is a primitive constant, so
+  // all three must be rejected
+  auto recordSel = [&](std::ostream& out) {
+    encode(MkRecord::type_case_id, out);
+    encode(static_cast<size_t>(1), out);               // one field...
+    encode(std::string("x"), out);                     // ...named x...
+    unitExpr(out);                                     // ...holding unit
+    encode(false, out);
+  };
+  auto varSel = [](std::ostream& out) {
+    encode(Var::type_case_id, out);
+    encode(std::string("x"), out);
+    encode(false, out);
+  };
+  auto nestedSwitchSel = [&](std::ostream& out) {
+    encode(Switch::type_case_id, out);
+    unitExpr(out);                                     // scrutinee: ()
+    encode(static_cast<size_t>(0), out);               // no bindings...
+    encode(true, out);                                 // ...but a default case,
+    unitExpr(out);                                     // so this switch is valid
+    encode(false, out);
+  };
 
-  // the value being switched over
-  out << expr(Unit::type_case_id); untyped(out);
+  std::vector<std::vector<uint8_t>> hostile;
+  hostile.push_back(switchWithSelectors({varSel}));
+  hostile.push_back(switchWithSelectors({nestedSwitchSel}));
+  // the record needs a preceding primitive selector to compare against: with a
+  // single binding the duplicate check never invokes the comparator, and it is
+  // that comparison which reached MkRecord::operator== in 549385905
+  hostile.push_back(switchWithSelectors({unitExpr, recordSel}));
 
-  // two bindings: the second selector is compared against the first, which is
-  // what reaches Primitive's virtuals
-  encode(static_cast<size_t>(2), out);
+  // Check the message, not merely that something was thrown: constructing a
+  // switch can throw on its own (inexhaustive coverage, duplicate selectors),
+  // so a test that only asked "did it throw" would pass with the check removed.
+  for (const auto& enc : hostile) {
+    // rejected where the expression is decoded ...
+    std::string msg;
+    try {
+      ExprPtr e;
+      decode(enc, &e);
+    } catch (const std::exception& ex) {
+      msg = ex.what();
+    }
+    EXPECT_TRUE(msg.find("primitive constant") != std::string::npos);
 
-  out << expr(Unit::type_case_id); untyped(out);   // selector 0: a unit constant
-  out << expr(Unit::type_case_id); untyped(out);   // its result expression
+    // ... and so also on the type-decoder surface the fuzzer drives, where the
+    // same bytes arrive wrapped in a type-level expression
+    std::vector<unsigned char> tenc;
+    auto append = [&](const void* p, size_t n) {
+      const auto* b = static_cast<const unsigned char*>(p);
+      tenc.insert(tenc.end(), b, b + n);
+    };
+    const int tag = TExpr::type_case_id;
+    const size_t len = enc.size();
+    append(&tag, sizeof(tag));
+    append(&len, sizeof(len));
+    tenc.insert(tenc.end(), enc.begin(), enc.end());
 
-  out << expr(MkRecord::type_case_id);             // selector 1: a record, not a constant
-  encode(static_cast<size_t>(1), out);             //   one field...
-  encode(std::string("x"), out);                   //   ...named x...
-  out << expr(Unit::type_case_id); untyped(out);   //   ...holding unit
-  untyped(out);
-  out << expr(Unit::type_case_id); untyped(out);   // its result expression
-
-  encode(false, out);                              // no default case
-  untyped(out);                                    // the switch carries no type
-
-  const std::string enc = out.str();
-  std::vector<uint8_t> raw(enc.begin(), enc.end());
-
-  {
-    stream::raw_istream<char> in(raw);
-    ExprPtr e;
-    bool threw = false;
-    try { decode(&e, in); } catch (const std::exception&) { threw = true; }
-    EXPECT_TRUE(threw);
+    msg.clear();
+    try {
+      decode(tenc);
+    } catch (const std::exception& ex) {
+      msg = ex.what();
+    }
+    EXPECT_TRUE(msg.find("primitive constant") != std::string::npos);
   }
-
-  // and through the surface the fuzzer drives: a TExpr type carries an encoded
-  // expression, so hobbes::decode(bytes) reaches the same decoder
-  std::vector<unsigned char> tenc;
-  const int texpr = TExpr::type_case_id;
-  const size_t len = enc.size();
-  tenc.insert(tenc.end(), reinterpret_cast<const unsigned char*>(&texpr),
-                          reinterpret_cast<const unsigned char*>(&texpr) + sizeof(texpr));
-  tenc.insert(tenc.end(), reinterpret_cast<const unsigned char*>(&len),
-                          reinterpret_cast<const unsigned char*>(&len) + sizeof(len));
-  tenc.insert(tenc.end(), enc.begin(), enc.end());
-
-  bool threw = false;
-  try { decode(tenc); } catch (const std::exception&) { threw = true; }
-  EXPECT_TRUE(threw);
 
   // a switch whose selectors really are primitive constants still round-trips
   Switch::Bindings bs;

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -179,3 +179,85 @@ TEST(TypeInf, CodecRejectsOversizedLengthOnNonSeekableStream) {
   decode(&s, gin);
   EXPECT_TRUE(s == "elephant");
 }
+
+TEST(TypeInf, DecodeRejectsNonPrimitiveSwitchSelector) {
+  // A switch binding holds its selector as a Primitive, and the switch
+  // constructor calls Primitive's virtuals on it (operator< via PrimPtrLT, to
+  // reject duplicate selectors). The selector is encoded as an ordinary
+  // expression, though, so a hostile buffer can name any expression case there
+  // -- a record, say. Converting that pointer unchecked dispatched Primitive's
+  // virtuals through the vtable of an unrelated Expr subclass and read past the
+  // end of the object (OSS-Fuzz 549385905, reached through hobbes::decode via
+  // an encoded TExpr type).
+  auto expr = [](int cid) {
+    std::ostringstream e;
+    encode(cid, e);
+    return e.str();
+  };
+  auto untyped = [](std::ostringstream& out) { encode(false, out); };
+
+  std::ostringstream out;
+  encode(Switch::type_case_id, out);
+
+  // the value being switched over
+  out << expr(Unit::type_case_id); untyped(out);
+
+  // two bindings: the second selector is compared against the first, which is
+  // what reaches Primitive's virtuals
+  encode(static_cast<size_t>(2), out);
+
+  out << expr(Unit::type_case_id); untyped(out);   // selector 0: a unit constant
+  out << expr(Unit::type_case_id); untyped(out);   // its result expression
+
+  out << expr(MkRecord::type_case_id);             // selector 1: a record, not a constant
+  encode(static_cast<size_t>(1), out);             //   one field...
+  encode(std::string("x"), out);                   //   ...named x...
+  out << expr(Unit::type_case_id); untyped(out);   //   ...holding unit
+  untyped(out);
+  out << expr(Unit::type_case_id); untyped(out);   // its result expression
+
+  encode(false, out);                              // no default case
+  untyped(out);                                    // the switch carries no type
+
+  const std::string enc = out.str();
+  std::vector<uint8_t> raw(enc.begin(), enc.end());
+
+  {
+    stream::raw_istream<char> in(raw);
+    ExprPtr e;
+    bool threw = false;
+    try { decode(&e, in); } catch (const std::exception&) { threw = true; }
+    EXPECT_TRUE(threw);
+  }
+
+  // and through the surface the fuzzer drives: a TExpr type carries an encoded
+  // expression, so hobbes::decode(bytes) reaches the same decoder
+  std::vector<unsigned char> tenc;
+  const int texpr = TExpr::type_case_id;
+  const size_t len = enc.size();
+  tenc.insert(tenc.end(), reinterpret_cast<const unsigned char*>(&texpr),
+                          reinterpret_cast<const unsigned char*>(&texpr) + sizeof(texpr));
+  tenc.insert(tenc.end(), reinterpret_cast<const unsigned char*>(&len),
+                          reinterpret_cast<const unsigned char*>(&len) + sizeof(len));
+  tenc.insert(tenc.end(), enc.begin(), enc.end());
+
+  bool threw = false;
+  try { decode(tenc); } catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(threw);
+
+  // a switch whose selectors really are primitive constants still round-trips
+  Switch::Bindings bs;
+  bs.push_back(Switch::Binding(
+    PrimitivePtr(new Bool(true, LexicalAnnotation::null())),
+    ExprPtr(new Unit(LexicalAnnotation::null()))));
+  bs.push_back(Switch::Binding(
+    PrimitivePtr(new Bool(false, LexicalAnnotation::null())),
+    ExprPtr(new Unit(LexicalAnnotation::null()))));
+  ExprPtr sw(new Switch(ExprPtr(new Unit(LexicalAnnotation::null())), bs, LexicalAnnotation::null()));
+
+  std::vector<uint8_t> good;
+  encode(sw, &good);
+  ExprPtr rt;
+  decode(good, &rt);
+  EXPECT_TRUE(*rt == *sw);
+}


### PR DESCRIPTION
Fixes two OSS-Fuzz reports of one defect, both found by `fuzz-type-decode`:

- [549385905](https://issues.oss-fuzz.com/issues/549385905) — `Heap-buffer-overflow READ 8` in `hobbes::MkRecord::operator==` (testcase 4688631038803968)
- [549508407](https://issues.oss-fuzz.com/issues/549508407) — `Bad-cast to hobbes::Primitive from hobbes::Switch`

## The defect

A `Switch` binding holds its selector as a `Primitive`, and `Switch::Switch` calls `Primitive`'s virtuals on it — `operator<`, through `PrimPtrLT`, to reject duplicate selectors.

The selector is encoded as an ordinary expression, though, and nothing in the encoding obliges a peer to put a primitive constant there. `decode(PrimitivePtr*, std::istream&)` `reinterpret_cast`ed the decoded `shared_ptr<Expr>` straight to `shared_ptr<Primitive>` without checking what came back:

```cpp
void decode(PrimitivePtr* p, std::istream& in) {
  decode(reinterpret_cast<ExprPtr*>(p), in);
}
```

So a buffer naming any other expression case there got its object treated as a `Primitive`, and the virtual call dispatched through the wrong vtable. What that lands on depends on the case named, which is why the same bug arrived as two different reports:

- a **record** selector reaches `MkRecord::operator==`, which reads its `std::vector` member past the end of the much smaller object actually allocated — the ASan heap-buffer-overflow;
- a **variable** or **nested switch** selector is caught earlier by UBSan as a bad cast.

`decodeTExpr` reaches the expression decoder from the type decoder, so `hobbes::decode()` on peer-supplied bytes — the RPC layer's untrusted surface, `ipc/net.C` decodes a peer's type descriptions before accepting any expression — is enough to trigger it:

```
==ERROR: AddressSanitizer: heap-buffer-overflow READ of size 8
    #1 hobbes::MkRecord::operator==(hobbes::MkRecord const&) const   lib/hobbes/lang/expr.C:444
    #2 hobbes::PrimPtrLT::operator()(...)                            lib/hobbes/lang/expr.C:45
    #6 hobbes::Switch::Switch(...)                                   lib/hobbes/lang/expr.C:679
    #8 hobbes::decode(std::shared_ptr<hobbes::Expr>*, std::istream&) lib/hobbes/lang/expr.C:1856
   #10 hobbes::decodeTExpr(...)                                      lib/hobbes/lang/type.C:2717
   #13 hobbes::decode(unsigned char const*, unsigned char const*)    lib/hobbes/lang/type.C:2751
   #14 LLVMFuzzerTestOneInput                                        fuzz/fuzz_type_decode.C:16
```

A UBSan build names the confusion directly: `member call on address ... which does not point to an object of type 'hobbes::Primitive' / note: object is of type 'hobbes::MkRecord'`.

## The change

`decode(PrimitivePtr*, std::istream&)` now decodes into an `ExprPtr` and converts with `dynamic_pointer_cast`, throwing when the input names something that is not a primitive constant — the same "reject malformed input" contract the rest of these decoders follow.

The two other unchecked casts around the same values go with it: `encode(const PrimitivePtr&, std::ostream&)` uses `static_pointer_cast`, and `Switch::clone()` uses `static_cast`, in place of `reinterpret_cast`s that happened to work only because `Expr` sits at offset 0 in `Primitive`.

## Test

`TypeInf/DecodeRejectsNonPrimitiveSwitchSelector` builds the hostile encodings from the codec's own primitives and covers all three selector shapes the two reports between them found — record, variable, nested switch — on both the expression decoder and the type-decoder surface the fuzzer drives, and checks that a switch whose selectors really are primitive constants still round-trips.

It asserts on the rejection message rather than merely that something was thrown: constructing a switch throws on its own for inexhaustive coverage and for duplicate selectors, so the weaker check passed even with the fix removed.

Verified against a `-DUSE_ASAN_AND_UBSAN=ON` build (clang 18, LLVM 18):

- with the fix reverted, the test fails and a hand-built fuzz reproducer gives an exact match for the reported crash signature — `heap-buffer-overflow READ of size 8` in `MkRecord::operator==` ← `PrimPtrLT::operator()` ← `Switch::Switch` ← `hobbes::decode`;
- with the fix applied, the reproducer is clean and the full `hobbes-test` suite passes.

## Age

Not a short-lived regression — the unchecked cast predates the public history, so every release is affected.
