### PR TITLE
Bound type substitution and reduction on decoded types

### DIFF
--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -1972,6 +1972,14 @@ public:
     auto si = this->s.find(v->name());
     if (si != this->s.end()) {
       if (this->transitive) {
+        // a substitution can be cyclic ('a' |-> 'a', or 'a' |-> 'b' with 'b' |-> 'a'),
+        // in which case it has no fixed point to reach -- unification avoids producing
+        // one, but a substitution derived from decoded type data can be cyclic, and
+        // expanding a variable already under expansion would never terminate
+        if (expanding(v->name())) {
+          return TVar::make(v->name());
+        }
+        expansion e(this, v->name());
         return switchOf(si->second, *this);
       } else {
         return si->second;
@@ -2003,6 +2011,29 @@ public:
 private:
   bool transitive;
   const MonoTypeSubst& s;
+
+  // the chain of type variables currently being expanded, held as stack frames
+  // linked through the visitor so that a cycle can be detected without allocating
+  struct expansion {
+    expansion(const substituteF* f, const std::string& n) : f(f), n(n), next(f->expansions) { f->expansions = this; }
+    ~expansion() { this->f->expansions = this->next; }
+    expansion(const expansion&) = delete;
+    expansion& operator=(const expansion&) = delete;
+
+    const substituteF* f;
+    const std::string& n;
+    const expansion*   next;
+  };
+  mutable const expansion* expansions = nullptr;
+
+  bool expanding(const std::string& n) const {
+    for (const expansion* e = this->expansions; e != nullptr; e = e->next) {
+      if (e->n == n) {
+        return true;
+      }
+    }
+    return false;
+  }
 };
 
 MonoTypePtr substituteStep(const MonoTypeSubst& s, const MonoTypePtr& mt) {
@@ -2091,17 +2122,41 @@ MonoTypes simplifyVarNames(const MonoTypes& mts) {
 }
 
 // reduce types to their ultimate primitive representation
-MonoTypePtr repType(const MonoTypePtr& t) {
-  if (const Prim* pt = is<Prim>(t)) {
-    if (pt->representation()) {
-      return repType(pt->representation());
+// type-level application is untyped, so a type description can describe a reduction
+// with no normal form (the type-level reading of '(\x.x x) (\x.x x)'). Type
+// descriptions are read from files and from network peers, so reduction is bounded
+// and the type rejected, rather than reduced until the stack runs out.
+static const size_t maxRepTypeSteps = 1000;
+
+// the step budget is shared with the reduction of the applied type function, so that
+// the whole reduction is bounded rather than each nested one starting over
+static MonoTypePtr repTypeWithin(const MonoTypePtr& ty, size_t* steps) {
+  MonoTypePtr t = ty;
+
+  while (true) {
+    if (*steps == 0) {
+      throw std::runtime_error("Type-level application does not reduce: " + show(ty));
     }
-  } else if (const TApp* a = is<TApp>(t)) {
-    if (const TAbs* tf = is<TAbs>(repType(a->fn()))) {
-      return repType(substitute(substitution(tf->args(), a->args()), tf->body()));
+    --*steps;
+
+    if (const Prim* pt = is<Prim>(t)) {
+      if (pt->representation()) {
+        t = pt->representation();
+        continue;
+      }
+    } else if (const TApp* a = is<TApp>(t)) {
+      if (const TAbs* tf = is<TAbs>(repTypeWithin(a->fn(), steps))) {
+        t = substitute(substitution(tf->args(), a->args()), tf->body());
+        continue;
+      }
     }
+    return t;
   }
-  return t;
+}
+
+MonoTypePtr repType(const MonoTypePtr& t) {
+  size_t steps = maxRepTypeSteps;
+  return repTypeWithin(t, &steps);
 }
 
 // one step of unrolling the representation type
@@ -2178,8 +2233,14 @@ public:
         return 0;
       } else if (f->name() == "promise") {
         return sizeof(long);
-      } else if (const TAbs* tf = is<TAbs>(f->representation())) {
-        return r(substitute(substitution(tf->args(), v->args()), tf->body()));
+      } else if (is<TAbs>(f->representation()) != nullptr) {
+        // reduce to a normal form first: recurring on a single reduction step
+        // would not terminate for an application that has no normal form
+        MonoTypePtr app = clone(v);
+        MonoTypePtr rty = repType(app);
+        if (rty != app) {
+          return r(rty);
+        }
       }
     }
     throw std::runtime_error("Can't determine size of monotype: " + show(v));

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -323,3 +323,50 @@ TEST(TypeInf, DecodeRejectsNonPrimitiveSwitchSelector) {
   decode(good, &rt);
   EXPECT_TRUE(*rt == *sw);
 }
+
+TEST(TypeInf, SubstitutionTerminatesOnCyclicSubstitutions) {
+  // substitution is applied to its fixed point, which only exists while no variable
+  // stands for a type that mentions it -- unification maintains that, but a
+  // substitution derived from decoded type data can be cyclic, and the fixed point it
+  // asks for is an infinite type
+  MonoTypeSubst self;
+  self["a"] = tvar("a");
+  EXPECT_TRUE(show(substitute(self, MonoTypePtr(tvar("a")))) == "a");
+
+  MonoTypeSubst nested;
+  nested["a"] = arrayty(tvar("a"));
+  EXPECT_TRUE(show(substitute(nested, MonoTypePtr(tvar("a")))) == "[a]");
+
+  MonoTypeSubst mutual;
+  mutual["a"] = tvar("b");
+  mutual["b"] = tvar("a");
+  EXPECT_TRUE(show(substitute(mutual, MonoTypePtr(tvar("a")))) == "a");
+
+  // an acyclic substitution must still be carried all the way to its fixed point
+  MonoTypeSubst chain;
+  chain["a"] = arrayty(tvar("b"));
+  chain["b"] = tvar("c");
+  chain["c"] = primty("int");
+  EXPECT_TRUE(show(substitute(chain, MonoTypePtr(tvar("a")))) == "[int]");
+}
+
+TEST(TypeInf, TypeApplicationReductionIsBounded) {
+  // '\x.(x x)' named as a type alias, so that applying it to itself is the type-level
+  // reading of the term whose reduction never reaches a normal form
+  auto omega = [](const std::string& n) {
+    return MonoTypePtr(
+      Prim::make(n, TAbs::make(str::strings("x"), TApp::make(tvar("x"), list(MonoTypePtr(tvar("x")))))));
+  };
+  MonoTypePtr diverges = TApp::make(omega("p"), list(omega("q")));
+
+  EXPECT_EXCEPTION(repType(diverges));
+  EXPECT_EXCEPTION(sizeOf(diverges));
+
+  // and as the field of a record, where laying the record out in memory is what
+  // reduces the application (this is how a decoded type reaches the reduction)
+  EXPECT_EXCEPTION(Record::make(list(Record::Member("f", diverges, 0))));
+
+  // an application that does reduce is still reduced, to a normal form
+  MonoTypePtr ident = Prim::make("id", TAbs::make(str::strings("x"), tvar("x")));
+  EXPECT_TRUE(show(repType(TApp::make(ident, list(primty("int"))))) == "int");
+}


### PR DESCRIPTION
`hobbes::decode` builds monotypes from bytes that can come from a file or from an
unauthenticated network peer (`ipc/net.C`), and laying out a decoded record forces its
field types to be reduced. Two reductions that terminate for every type the compiler
builds do not terminate for every type that can be decoded, and each one runs the stack
out.

**Cyclic substitutions.** `substitute()` applies a substitution to its fixed point, which
only exists while no variable stands for a type that mentions it. Unification maintains
that, but the substitution built to apply a decoded type function need not: `(\a.a) (\().a)`
substitutes `a` for a type whose body is `a` again, and `substituteF::with(TVar)` expands
it forever. This tracks the variables under expansion and stops at the first repeat,
leaving the occurrence as a variable. This is the OSS-Fuzz report: fuzz-type-decode, stack
overflow in `hobbes::substituteF::with`, 110 bytes of input.

**Non-normalizing type applications.** Type-level application is untyped, so a decoded
application can describe a reduction with no normal form — the type-level reading of
`(\x.x x) (\x.x x)` — which `repType()` and `sizeOf()` reduce until the stack runs out.
This bounds the number of reduction steps (shared across nested reductions, so the whole
reduction is bounded rather than each nested one starting over) and rejects the type, and
lets `sizeOf()` reduce through `repType()` rather than recurring on a single step at a time.

Both are old bugs: `substituteF` has expanded transitively since the type system was
introduced, and neither reduction has ever been bounded. Neither is reachable from source
text, which the type checker keeps acyclic; they need a type description that was not
produced by the compiler.

Tests: `TypeInf/SubstitutionTerminatesOnCyclicSubstitutions` covers self, nested, and
mutual cycles plus an acyclic chain that must still reach its fixed point;
`TypeInf/TypeApplicationReductionIsBounded` covers `repType`, `sizeOf`, and record layout
on a non-normalizing application, plus one that does reduce. Full suite passes locally.
