### PR TITLE
Bound type size and record layout arithmetic

### DIFF
--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -1170,22 +1170,39 @@ MonoTypePtr Record::tailType() const {
   }
 }
 
+// a type description can be read from a file or handed over by an untrusted
+// peer, naming member sizes that no value in memory could have. A member offset
+// is held in an 'int' (with -1 reserved for 'not yet determined'), so a layout
+// running past INT_MAX has no representation here: determine it in a 'long' and
+// reject it at that bound, rather than wrapping around into a nonsensical one.
+static const long maxRecordOffset = static_cast<long>(std::numeric_limits<int>::max());
+
+static bool representableOffset(long o) { return o >= 0 && o <= maxRecordOffset; }
+
 Record::Members Record::withResolvedMemoryLayout(const Members& ms) {
   Members r;
 
   // infer offsets and/or insert padding as necessary
-  int o = 0;
+  long o = 0;
   for (auto m = ms.begin(); m != ms.end(); ++m) {
     if (!isMonoSingular(m->type)) {
       return ms;
     }
 
-    o = align<unsigned int>(o, alignment(m->type));
+    o = align<long>(o, static_cast<long>(alignment(m->type)));
+    if (!representableOffset(o)) {
+      throw
+        std::runtime_error(
+          "Member offset is out of range at field '" + m->field + "' "
+          "(" + str::from(o) + " is not within [0, " + str::from(maxRecordOffset) + "]) in record: " +
+          showRecord(ms)
+        );
+    }
 
     // determine the 'in-memory' layout of this structure
     //   (must be consistent with GCC so that we can interoperate)
     if (m->offset == -1) {
-      r.push_back(addoffset(*m, o));
+      r.push_back(addoffset(*m, static_cast<int>(o)));
     } else if (m->offset > o) {
       throw
         std::runtime_error(
@@ -1206,6 +1223,14 @@ Record::Members Record::withResolvedMemoryLayout(const Members& ms) {
     }
 
     o += sizeOf(m->type);
+    if (!representableOffset(o)) {
+      throw
+        std::runtime_error(
+          "Record extends past the end of the memory layout at field '" + m->field + "' "
+          "(" + str::from(o) + " is not within [0, " + str::from(maxRecordOffset) + "]) in record: " +
+          showRecord(ms)
+        );
+    }
   }
 
   return r;
@@ -1240,7 +1265,17 @@ unsigned int Record::size() const {
     size_t fsz = sizeOf(m->type);
 
     if (fsz > 0) {
-      return align<unsigned int>(m->offset + fsz, malign);
+      const long sz =
+        align<long>(static_cast<long>(m->offset) + static_cast<long>(fsz), static_cast<long>(malign));
+      if (!representableOffset(sz)) {
+        throw
+          std::runtime_error(
+            "Record size is out of range "
+            "(" + str::from(sz) + " is not within [0, " + str::from(maxRecordOffset) + "]) in record: " +
+            showRecord(this->ms)
+          );
+      }
+      return static_cast<unsigned int>(sz);
     }
   }
 
@@ -1250,15 +1285,18 @@ unsigned int Record::size() const {
 
 Record::Members Record::withExplicitPadding(const Members& ms, const std::string& pfx) {
   Members r;
-  int     o = 0; // the active determined offset in memory
+  long    o = 0; // the active determined offset in memory
   int     p = 0; // unique names for pad fields
 
+  // as in withResolvedMemoryLayout, the offset is tracked in a 'long': an
+  // offset and a size taken from a decoded type description are added and
+  // differenced here, and neither the sum nor the gap need fit in an 'int'
   for (const auto &m : ms) {
     if (m.offset > o) {
-      r.push_back(Member(pfx + str::from(p++), arrayty(prim<char>(), m.offset - o)));
+      r.push_back(Member(pfx + str::from(p++), arrayty(prim<char>(), static_cast<size_t>(m.offset - o))));
     }
     size_t msz = sizeOf(m.type);
-    o = m.offset + msz;
+    o = static_cast<long>(m.offset) + static_cast<long>(msz);
 
     if (msz > 0) {
       r.push_back(m);
@@ -1269,9 +1307,9 @@ Record::Members Record::withExplicitPadding(const Members& ms, const std::string
   unsigned int talign = maxFieldAlignmentF(ms);
 
   if (talign > 0) {
-    auto asz = align<unsigned int>(o, talign);
-    if (int(asz) > o) {
-      r.push_back(Member(pfx + str::from(p++), arrayty(prim<char>(), asz - o)));
+    const long asz = align<long>(o, static_cast<long>(talign));
+    if (asz > o) {
+      r.push_back(Member(pfx + str::from(p++), arrayty(prim<char>(), static_cast<size_t>(asz - o))));
     }
   }
 
@@ -2136,7 +2174,22 @@ public:
   nat with(const OpaquePtr*  v) const override { return v->storedContiguously() ? v->size() : sizeof(void*); }
   [[noreturn]] nat with(const TVar*       v) const override { throw std::runtime_error("Can't determine size of type variable '" + v->name() + "'"); }
   [[noreturn]] nat with(const TGen*       v) const override { throw std::runtime_error("Can't determine size of polytype argument #" + str::from(v->id())); }
-  nat with(const FixedArray* v) const override { return r(v->type()) * v->requireLength(); }
+  nat with(const FixedArray* v) const override {
+    // the length is part of a type description that can be read from a file or
+    // handed over by an untrusted peer, and the size is returned as a 'nat', so
+    // a length that cannot describe a value in memory has to be rejected rather
+    // than multiplied out into a wrapped-around answer
+    const long len = v->requireLength();
+    if (len < 0) {
+      throw std::runtime_error("Can't determine size of array of negative length: " + show(v));
+    }
+
+    const nat esz = r(v->type());
+    if (esz != 0 && static_cast<unsigned long>(len) > (std::numeric_limits<nat>::max() / esz)) {
+      throw std::runtime_error("Array size exceeds the maximum representable type size: " + show(v));
+    }
+    return static_cast<nat>(esz * static_cast<unsigned long>(len));
+  }
   nat with(const Array*       ) const override { return sizeof(void*); }
   nat with(const Variant*    v) const override { return rv(v); }
   nat with(const Record*     v) const override { return rv(v); }

--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -1307,7 +1307,20 @@ Record::Members Record::withExplicitPadding(const Members& ms, const std::string
   unsigned int talign = maxFieldAlignmentF(ms);
 
   if (talign > 0) {
+    // a record that ends exactly at the last representable offset is within
+    // range until it is aligned, and aligning it here is what would carry it
+    // past: reject it rather than describing a padded layout whose extent no
+    // offset or size can hold (Record::size() refuses to size such a record, so
+    // without this it exists only to throw the first time anything asks)
     const long asz = align<long>(o, static_cast<long>(talign));
+    if (!representableOffset(asz)) {
+      throw
+        std::runtime_error(
+          "Record with trailing padding is out of range "
+          "(" + str::from(asz) + " is not within [0, " + str::from(maxRecordOffset) + "]) in record: " +
+          showRecord(ms)
+        );
+    }
     if (asz > o) {
       r.push_back(Member(pfx + str::from(p++), arrayty(prim<char>(), static_cast<size_t>(asz - o))));
     }

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -92,6 +92,82 @@ TEST(TypeInf, DecodeRejectsOutOfRangeTGen) {
   }
 }
 
+TEST(TypeInf, SizeAndLayoutRejectUnrepresentableTypes) {
+  // A type description can be read from a file or handed over by an untrusted
+  // peer, and nothing in it is bounded by what a value in memory could be. The
+  // size of a type is computed as an 'unsigned int' and a record member offset
+  // is held in an 'int' (with -1 reserved for 'not yet determined'), so a
+  // fixed array long enough to run past those used to be multiplied and summed
+  // through signed overflow -- undefined behavior -- into a wrapped-around
+  // layout. Such a type has no representation here and must be rejected.
+  const MonoTypePtr huge(FixedArray::make(primty("long"), MonoTypePtr(TLong::make(std::numeric_limits<long>::max()))));
+
+  // sizing the array on its own is rejected: this is the multiplication that
+  // overflowed, 8 bytes an element by a length only the encoding bounds
+  EXPECT_EXCEPTION(sizeOf(huge));
+
+  // a length that multiplies out without overflowing, but still to a size no
+  // value can have, is out of range just the same
+  EXPECT_EXCEPTION(sizeOf(MonoTypePtr(FixedArray::make(primty("char"), MonoTypePtr(TLong::make(0x100000000L))))));
+
+  // as is any record laid out over it
+  EXPECT_EXCEPTION(Record::make(list(Record::Member("a", huge))));
+
+  // a negative length describes no array at all
+  EXPECT_EXCEPTION(sizeOf(MonoTypePtr(FixedArray::make(primty("char"), MonoTypePtr(TLong::make(-1))))));
+
+  // members that each fit but together run past the end of the layout are
+  // rejected too -- here it is the running offset that goes out of range
+  const MonoTypePtr big(FixedArray::make(primty("char"), MonoTypePtr(TLong::make(0x40000000))));
+  Record::Members ms;
+  for (size_t i = 0; i < 4; ++i) {
+    ms.push_back(Record::Member(".f" + str::from(i), big));
+  }
+  EXPECT_EXCEPTION(Record::make(ms));
+
+  // and the same record arriving as an encoded type description -- which is
+  // what the binary decoder consumes -- is rejected rather than crashing it
+  std::vector<unsigned char> enc;
+  auto put = [&](const void* p, size_t n) {
+    const auto* b = static_cast<const unsigned char*>(p);
+    enc.insert(enc.end(), b, b + n);
+  };
+  const int          tcode  = Record::type_case_id;
+  const size_t       nmems  = 1;
+  const size_t       namesz = 1;
+  const unsigned int offset = static_cast<unsigned int>(-1); // 'determine this offset'
+  put(&tcode,  sizeof(tcode));
+  put(&nmems,  sizeof(nmems));
+  put(&namesz, sizeof(namesz));
+  put("a", 1);
+  put(&offset, sizeof(offset));
+  encode(huge, &enc);
+
+  bool threw = false;
+  try { decode(enc); } catch (const std::exception&) { threw = true; }
+  EXPECT_TRUE(threw);
+
+  // sizes that do fit are unaffected, including an empty array of a type too
+  // large to have any elements
+  EXPECT_EQ(sizeOf(arrayty(primty("int"), 4)), 16U);
+  EXPECT_EQ(sizeOf(MonoTypePtr(FixedArray::make(big, MonoTypePtr(TLong::make(0))))), 0U);
+  EXPECT_EQ(sizeOf(tuplety(list(primty("char"), primty("int")))), 8U);
+
+  // ordinary records are laid out as before
+  const MonoTypePtr rty =
+    Record::make(list(Record::Member("a", primty("char")), Record::Member("b", primty("long"))));
+  EXPECT_EQ(sizeOf(rty), 16U);
+
+  const Record* rec = is<Record>(rty);
+  EXPECT_TRUE(rec != nullptr);
+  EXPECT_EQ(rec->alignedMembers().size(), size_t(3)); // 'a', 7 bytes of padding, 'b'
+
+  // and one whose members do fit still decodes to the layout it describes
+  std::vector<unsigned char> ok;
+  encode(Record::make(list(Record::Member("x", arrayty(primty("int"), 4), 0))), &ok);
+  EXPECT_EQ(sizeOf(decode(ok)), 16U);
+}
+
 TEST(TypeInf, CodecRejectsInvalidBoolValue) {
   // the stream codec decodes data that can arrive from an untrusted peer;
   // loading any byte other than 0 or 1 into a bool is undefined behavior, so

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -125,6 +125,17 @@ TEST(TypeInf, SizeAndLayoutRejectUnrepresentableTypes) {
   }
   EXPECT_EXCEPTION(Record::make(ms));
 
+  // a record that ends exactly at the last representable offset is in range
+  // until its trailing padding is added, and adding it is what carries the
+  // layout past what an offset can hold -- so that record is rejected too,
+  // rather than being built and then refusing to give its size
+  EXPECT_EXCEPTION(
+    Record::make(list(
+      Record::Member("a", primty("long")),
+      Record::Member("b", MonoTypePtr(FixedArray::make(primty("char"), MonoTypePtr(TLong::make(std::numeric_limits<int>::max() - 8)))))
+    ))
+  );
+
   // and the same record arriving as an encoded type description -- which is
   // what the binary decoder consumes -- is rejected rather than crashing it
   std::vector<unsigned char> enc;


### PR DESCRIPTION
Fixes two OSS-Fuzz reports of one missing bound, both found by `fuzz-type-decode` under UBSan:

- [549508406](https://issues.oss-fuzz.com/issues/549508406) — `Integer-overflow in hobbes::sizeOfF::with`
- [549508405](https://issues.oss-fuzz.com/issues/549508405) — `Integer-overflow in hobbes::Record::withExplicitPadding` (testcase 5921676318801920)

Both land on the same multiplication:

```
lib/hobbes/lang/type.C:2129:70: runtime error: signed integer overflow:
4 * 2305843009213693952 cannot be represented in type 'long'
```

## The defect

`sizeOfF` sized a fixed array by multiplying its element size by its length:

```cpp
nat with(const FixedArray* v) const override {
  return r(v->type()) * v->requireLength();
}
```

`requireLength()` returns the `long` carried by the type's `TLong` length, so the element size widens to `long` and the product is a signed multiply. The decoder takes that length straight off the wire (`decodeFixedArr` → `FixedArray::make`), and `hobbes::decode` runs on bytes read from a structured data file or handed over by an unauthenticated peer before any expression is accepted (`ipc/net.C`) — per [SECURITY.md](SECURITY.md) that buffer is untrusted, so the length is whatever the peer wrote down. `[:int|2^61:]` overflows the multiply; a negative length instead produced a negative product that was read back as a very large unsigned size.

The two reports differ only in how they reach it: directly through `sizeOf`, or one frame up while a record naming such an array has its memory layout resolved.

The record layout arithmetic downstream of it was as narrow. `withResolvedMemoryLayout` and `withExplicitPadding` both accumulated the running offset in an `int` while adding unsigned member sizes, so the addition ran as unsigned and wrapped: a sequence of members that each fit could still carry the offset past `INT_MAX`, leaving a member holding a negative offset rather than an error, and `withExplicitPadding` differenced two of those `int`s to size a pad field.

## The fix

A memory size is a `nat` (`unsigned int`), so an array whose byte count doesn't fit there has no size to compute. Check that the length is not negative and that the product is representable before multiplying, and throw otherwise — the same answer `sizeOf` already gives for a type variable or a type abstraction.

A member offset is held in an `int` (with `-1` reserved for "not yet determined"), so a layout running past `INT_MAX` has no representation here at all: determine it in a `long`, and reject it at that bound instead of wrapping into a nonsensical layout. `Record::size()` computes in a `long` for the same reason.

No valid type is affected — a record that fits in memory is far below the bound.

## Provenance

Old bug, not a short-lived regression: the multiply and the layout arithmetic are unchanged since the original record layout code, so every release carries them. They became reachable by a fuzzer when `fuzz-type-decode` was added, and the RPC path has always been able to reach them with a hostile type description. Outside a UBSan build the effect was a wrong size or a nonsensical layout rather than a crash.

## Testing

`TypeInf/SizeAndLayoutRejectUnrepresentableTypes` builds the offending types directly — an array too long to size, one that multiplies out without overflowing but still past what a `nat` holds, a negative length, and members that each fit but together run the offset out of range — and feeds the same record through `hobbes::decode` as an encoded type description, which is what the harness consumes. It fails without this change. The positive cases cover ordinary sizes, an empty array of a large element type, and a well-formed record decoding to the layout it describes.
