### PR TITLE
Bound how deeply a parsed expression may nest

### DIFF
--- a/fuzz/corpus/parse-expr/nested_ops.hob
+++ b/fuzz/corpus/parse-expr/nested_ops.hob
@@ -1,0 +1,1 @@
+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x+x

--- a/include/hobbes/lang/expr.H
+++ b/include/hobbes/lang/expr.H
@@ -72,6 +72,18 @@ std::string showAnnotated(const Expr* e);
 std::string showAnnotated(const ExprPtr& e);
 std::string showAnnotated(const Definition& d);
 
+// the sub-expressions immediately under an expression
+Exprs subExprs(const ExprPtr&);
+
+// how many levels of expression an expression nests, determined with an
+// explicit stack so that it can be asked of a tree too deep to walk recursively
+size_t nestingDepth(const ExprPtr&);
+
+// release an expression, one level at a time rather than through the recursive
+// destructor chain that dropping the root would otherwise run (so a tree of any
+// depth can be discarded safely)
+void releaseNesting(ExprPtr&);
+
 //////////////////
 // primitive constants
 //////////////////

--- a/lib/hobbes/lang/expr.C
+++ b/lib/hobbes/lang/expr.C
@@ -5,8 +5,11 @@
 #include <hobbes/util/time.H>
 #include <hobbes/util/codec.H>
 #include <hobbes/util/stream.H>
+#include <algorithm>
 #include <memory>
 #include <sstream>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace hobbes {
 
@@ -1022,6 +1025,156 @@ struct isConstP : switchExprC<bool> {
 
 bool isConst(const ExprPtr& e) {
   return switchOf(e, isConstP());
+}
+
+// the sub-expressions immediately under an expression
+struct subExprsF : public switchExprC<Exprs> {
+  Exprs withConst(const Expr*) const override { return Exprs(); }
+  Exprs with(const Var*)       const override { return Exprs(); }
+
+  Exprs with(const Let* v) const override { return list(v->varExpr(), v->bodyExpr()); }
+
+  Exprs with(const LetRec* v) const override {
+    Exprs r;
+    for (const auto& b : v->bindings()) {
+      r.push_back(b.second);
+    }
+    r.push_back(v->bodyExpr());
+    return r;
+  }
+
+  Exprs with(const Fn* v) const override { return list(v->body()); }
+
+  Exprs with(const App* v) const override {
+    Exprs r = list(v->fn());
+    r.insert(r.end(), v->args().begin(), v->args().end());
+    return r;
+  }
+
+  Exprs with(const Assign* v)    const override { return list(v->left(), v->right()); }
+  Exprs with(const MkArray* v)   const override { return v->values(); }
+  Exprs with(const MkVariant* v) const override { return list(v->value()); }
+
+  Exprs with(const MkRecord* v) const override {
+    Exprs r;
+    for (const auto& f : v->fields()) {
+      r.push_back(f.second);
+    }
+    return r;
+  }
+
+  Exprs with(const AIndex* v) const override { return list(v->array(), v->index()); }
+
+  Exprs with(const Case* v) const override {
+    Exprs r = list(v->variant());
+    for (const auto& b : v->bindings()) {
+      r.push_back(b.exp);
+    }
+    if (v->defaultExpr()) {
+      r.push_back(v->defaultExpr());
+    }
+    return r;
+  }
+
+  // a switch selects on constants, so only its branches are sub-expressions
+  Exprs with(const Switch* v) const override {
+    Exprs r = list(v->expr());
+    for (const auto& b : v->bindings()) {
+      r.push_back(b.exp);
+    }
+    if (v->defaultExpr()) {
+      r.push_back(v->defaultExpr());
+    }
+    return r;
+  }
+
+  Exprs with(const Proj* v)   const override { return list(v->record()); }
+  Exprs with(const Assump* v) const override { return list(v->expr()); }
+  Exprs with(const Pack* v)   const override { return list(v->expr()); }
+  Exprs with(const Unpack* v) const override { return list(v->package(), v->expr()); }
+};
+
+Exprs subExprs(const ExprPtr& e) {
+  return e ? switchOf(e, subExprsF()) : Exprs();
+}
+
+// the two functions below walk expressions with an explicit stack rather than
+// by recursion: they are what a caller reaches for when a tree may be nested
+// more deeply than the call stack can follow, so they cannot recur themselves
+
+size_t nestingDepth(const ExprPtr& root) {
+  if (!root) {
+    return 0;
+  }
+
+  // an expression can reach the same sub-expression by more than one path, so
+  // depths are memoized -- without that, a tree of shared sub-expressions takes
+  // exponential time to measure
+  std::unordered_map<const Expr*, size_t> depths;
+  std::unordered_set<const Expr*>         pushed;
+
+  using Frame = std::pair<ExprPtr, bool>; // the expression, and whether its children are on the stack
+  std::vector<Frame> stack;
+  stack.push_back(Frame(root, false));
+  pushed.insert(root.get());
+
+  while (!stack.empty()) {
+    if (!stack.back().second) {
+      stack.back().second = true;
+
+      const Exprs cs = subExprs(stack.back().first);
+      for (const auto& c : cs) {
+        if (c && pushed.insert(c.get()).second) {
+          stack.push_back(Frame(c, false));
+        }
+      }
+    } else {
+      const ExprPtr e = stack.back().first;
+      stack.pop_back();
+
+      size_t d = 1;
+      for (const auto& c : subExprs(e)) {
+        if (c) {
+          d = std::max(d, depths[c.get()] + 1);
+        }
+      }
+      depths[e.get()] = d;
+    }
+  }
+
+  return depths[root.get()];
+}
+
+void releaseNesting(ExprPtr& root) {
+  if (!root) {
+    return;
+  }
+
+  // hold a reference to every sub-expression before letting go of the root:
+  // with that second reference in hand, releasing a level only decrements its
+  // children rather than destroying them in turn, so the destructor chain never
+  // runs deeper than one level
+  Exprs nodes;
+  Exprs pending = list(root);
+  root.reset();
+
+  while (!pending.empty()) {
+    const ExprPtr e = pending.back();
+    pending.pop_back();
+
+    for (const auto& c : subExprs(e)) {
+      if (c) {
+        pending.push_back(c);
+      }
+    }
+    nodes.push_back(e);
+  }
+
+  // released from the root down, so that each level is already unreferenced by
+  // its parent by the time it is dropped here
+  for (auto& n : nodes) {
+    n.reset();
+  }
 }
 
 // a convenient encapsulation of type-directed term transformation (e.g.: for unqualification)

--- a/lib/hobbes/read/parser.C
+++ b/lib/hobbes/read/parser.C
@@ -102,6 +102,33 @@ template <typename T>
 // touching the checked-in generated parser, which is not worth the risk for
 // the exposure. Revisit if a path ever parses attacker-controlled input in a
 // tight loop without restarting.
+
+// Every function that walks an expression recurs through its levels of nesting
+// -- type inference, unsweetening, printing, and the expression's own
+// destructor -- so how deeply an expression nests is stack depth in everything
+// downstream of the parse, and the parser will build a tree as deep as its
+// input describes. Source nested this deeply is not written by hand; it is
+// generated, or it is hostile: reading source text is on the near side of the
+// trust boundary (see SECURITY.md), and `x+x+x...` repeated enough times is all
+// it takes. Bound it here, where every expression the parser returns has to
+// pass, rather than in each of those walks.
+const size_t maxExprNestingDepth = 1000;
+
+// takes the expression by pointer, and must be given the only reference to it:
+// an expression past the limit is let go here one level at a time, and a second
+// reference left anywhere would run the destructor chain that the limit is
+// meant to prevent when it went out of scope
+void checkNestingDepth(ExprPtr* e) {
+  const size_t d = nestingDepth(*e);
+  if (d > maxExprNestingDepth) {
+    releaseNesting(*e);
+
+    throw std::runtime_error(
+      "Expression nests " + str::from(d) + " levels deep, past the limit of " + str::from(maxExprNestingDepth)
+    );
+  }
+}
+
 void runParserOnBuffer(cc* c, int initTok, YY_BUFFER_STATE bs) {
   yyParseCC   = c;
   yyInitToken = initTok;
@@ -190,7 +217,9 @@ ExprDefn defReadExprDefn(cc* c, const std::string& expr) {
   yyParsedExpr = nullptr;
   runParserOnString(c, TPARSEDEFN, expr.c_str());
 
-  return ExprDefn(yyParsedVar, checkReturn(yyParsedExpr != nullptr ? ExprPtr(yyParsedExpr) : ExprPtr()));
+  ExprPtr e = checkReturn(yyParsedExpr != nullptr ? ExprPtr(yyParsedExpr) : ExprPtr());
+  checkNestingDepth(&e);
+  return ExprDefn(yyParsedVar, e);
 }
 
 ExprPtr defReadExpr(cc* c, const std::string& expr) {
@@ -199,7 +228,9 @@ ExprPtr defReadExpr(cc* c, const std::string& expr) {
   yyParsedExpr = nullptr;
   runParserOnString(c, TPARSEEXPR, expr.c_str());
 
-  return checkReturn(yyParsedExpr != nullptr ? ExprPtr(yyParsedExpr) : ExprPtr());
+  ExprPtr e = checkReturn(yyParsedExpr != nullptr ? ExprPtr(yyParsedExpr) : ExprPtr());
+  checkNestingDepth(&e);
+  return e;
 }
 
 // allow variable and pattern variable overloading

--- a/test/Parse.C
+++ b/test/Parse.C
@@ -1,0 +1,67 @@
+#include "test.H"
+#include <hobbes/hobbes.H>
+#include <string>
+
+using namespace hobbes;
+
+static cc& c() { static __thread cc* x = nullptr; if (x == nullptr) { x = new cc(); } return *x; }
+
+// an expression whose operators associate to the left nests one level per term,
+// while the parser's own stack stays flat -- so the tree it builds is as deep as
+// the input describes
+static std::string leftNestedSum(size_t terms) {
+  std::string r = "x";
+  for (size_t i = 0; i < terms; ++i) {
+    r += "+x";
+  }
+  return r;
+}
+
+TEST(Parse, DeeplyNestedExpressionsAreRejected) {
+  // reading source text is on the near side of the trust boundary (see
+  // SECURITY.md), and every walk over a parsed expression recurs through its
+  // nesting -- the expression's own destructor first among them. Deep enough
+  // input used to run the stack out rather than being rejected; the depth here
+  // is well past what a stack can hold, so an unfixed build crashes on it
+  // rather than failing this test
+  EXPECT_EXCEPTION(c().readExpr(leftNestedSum(150000)));
+
+  // the same is true of a chain of applications
+  std::string apps = "f";
+  for (size_t i = 0; i < 150000; ++i) {
+    apps += "(1)";
+  }
+  EXPECT_EXCEPTION(c().readExpr(apps));
+
+  // and the process is still usable afterwards -- the rejected expression was
+  // released a level at a time rather than through the recursive destructor
+  // chain that dropping it would otherwise run
+  EXPECT_EQ(show(c().readExpr("1+2")), "+(1, 2)");
+}
+
+TEST(Parse, ExpressionsWithinTheNestingLimitStillParse) {
+  // ordinary expressions are nowhere near the limit, and expressions that are
+  // deeply nested but still within it read as they always have
+  EXPECT_TRUE(c().readExpr(leftNestedSum(500)) != nullptr);
+
+  std::string hundred = "0";
+  for (size_t i = 0; i < 100; ++i) {
+    hundred += "+1";
+  }
+  EXPECT_EQ(c().compileFn<int()>(hundred)(), 100);
+}
+
+TEST(Parse, NestingDepthAndRelease) {
+  // nesting depth counts levels of expression, so a variable is one level and
+  // each operator applied to it adds another
+  EXPECT_EQ(nestingDepth(c().readExpr("x")), size_t(1));
+  EXPECT_EQ(nestingDepth(c().readExpr("x+1")), size_t(2));
+  EXPECT_EQ(nestingDepth(c().readExpr("(x+1)*2")), size_t(3));
+
+  // and both it and the level-at-a-time release run without recursing, so they
+  // hold up on a tree too deep to walk recursively
+  ExprPtr e = c().readExpr(leftNestedSum(500));
+  EXPECT_EQ(nestingDepth(e), size_t(501));
+  releaseNesting(e);
+  EXPECT_TRUE(e == nullptr);
+}


### PR DESCRIPTION
Fixes [OSS-Fuzz 549830768](https://issues.oss-fuzz.com/issues/549830768) (testcase 4551524139991040), a stack overflow in `fuzz-parse-expr` under ASan whose crash state names no frame beyond the harness:

```
Crash Type: Stack-overflow
Crash State:
  fuzz-parse-expr
```

## The defect

The parser builds an expression as deeply nested as its input describes, and every walk over the result recurs through that nesting — type inference, unsweetening, printing, and the expression's own destructor first among them.

The parser's own stack does not grow with it. Operators associate to the left, so a chain like `x+x+x...` reduces at a constant parse-stack depth (bison stops at 200 entries with "memory exhausted", which is what bounds *right*-nested input) while the tree it builds gains a level per term. Nothing bounds that, so a long enough chain of any left-associative form — `+`, `or`, `f(1)(1)...` — produces a tree that cannot be walked, and dropping it runs the destructor chain off the end of the stack.

Reading source text is on the near side of the trust boundary (see [SECURITY.md](SECURITY.md)) — which is why it is fuzzed at all.

Reproduced by replaying the harness on a chain of 200,000 terms:

```
stop reason = EXC_BAD_ACCESS (code=2, address=0x16f603ff0)
  frame #0: hobbes::Var::~Var()
```

The same input parses fine if the resulting expression is deliberately leaked rather than released, which places the crash in teardown rather than in the parse. An `-O2` build on an 8MB stack crosses the limit at about 104,000 levels of nesting; the instrumented build OSS-Fuzz runs, whose frames are several times larger, crosses it much sooner.

## The fix

`checkNestingDepth` bounds nesting where every expression the parser returns has to pass — `defReadExpr` and `defReadExprDefn` — rejecting anything past `maxExprNestingDepth` (1000).

A rejected expression can't be dropped the ordinary way; that is the destructor chain the bound exists to prevent. So it is released a level at a time instead, which is why this adds two utilities to `expr.C` alongside the sub-expression enumeration they share:

```cpp
Exprs  subExprs(const ExprPtr&);      // the sub-expressions under one node
size_t nestingDepth(const ExprPtr&);  // levels of nesting, walked iteratively
void   releaseNesting(ExprPtr&);      // release without the destructor cascade
```

`releaseNesting` takes a reference to every node before letting go of the root, so each level's destructor only decrements its children rather than destroying them in turn — the chain never runs deeper than one level. Both walk with an explicit stack: they exist for trees too deep to walk recursively, so they can't recur themselves.

## Provenance

Old bug, not a short-lived regression: expression nesting has been unbounded since the grammar was written, so every release is affected. It became reachable by a fuzzer when `fuzz-parse-expr` was added.

## What is not covered

Module definitions carry expressions parsed by the same grammar and are reached through a different entry point (`readModule`). Bounding those means walking module definitions and releasing an offending expression through its definition; this change leaves that path alone.

## Testing

- `test/Parse.C` covers the rejection (chains of 150,000 terms — past what a stack holds, so an **unfixed build crashes on it** rather than failing the test), that the compiler is still usable afterwards, that expressions within the limit parse and evaluate as before, and the two new utilities directly. Verified both ways: with `parser.C` reverted the group exits 139; with the fix it passes.
- Full `hobbes-test` suite passes.
- All 133 rosetta examples pass, so no real program comes near the limit.
- The check costs ~8µs on an expression that takes ~575µs to parse (20,000 iterations, `-O2`).
- A seed with a nested operator chain goes into the `parse-expr` corpus, which had nothing exercising left-associative nesting.
