### PR TITLE
Bound how deeply an encoded description may nest

### DIFF
--- a/include/hobbes/util/codec.H
+++ b/include/hobbes/util/codec.H
@@ -115,6 +115,35 @@ inline void ensureAvail(std::istream& in, size_t n, size_t esz) {
   }
 }
 
+// A type or expression description nests as deeply as its bytes say it does,
+// and decoding recurses once per level -- as does everything that walks the
+// result afterwards, including its own destructor. That data is untrusted (see
+// SECURITY.md: it is read from files and handed over by network peers), so
+// nesting is bounded here, in a guard the decoders take at each level, rather
+// than by running the stack out on a description that is merely deep.
+//
+// The bound is above the nesting the compiler itself will build, so anything
+// hobbes can produce still round-trips through the codec.
+static const unsigned int maxDecodeNesting = 2000;
+
+inline thread_local unsigned int decodeNestingDepth = 0;
+
+class decodeNesting {
+public:
+  decodeNesting() {
+    if (decodeNestingDepth >= maxDecodeNesting) {
+      throw std::runtime_error(
+        "Encoded data nests more than " + std::to_string(maxDecodeNesting) + " levels deep"
+      );
+    }
+    ++decodeNestingDepth;
+  }
+  ~decodeNesting() { --decodeNestingDepth; }
+
+  decodeNesting(const decodeNesting&) = delete;
+  decodeNesting& operator=(const decodeNesting&) = delete;
+};
+
 inline void encode(const std::string& x, std::ostream& out) {
   encode(static_cast<size_t>(x.size()), out);
   out.write(x.c_str(), x.size());

--- a/lib/hobbes/lang/expr.C
+++ b/lib/hobbes/lang/expr.C
@@ -1690,6 +1690,11 @@ void encode(const ExprPtr& e, std::ostream& out) {
 }
 
 void decode(ExprPtr* out, std::istream& in) {
+  // as with types, every nested expression is decoded through here: an
+  // expression description nests as deeply as its bytes say, and the decoder
+  // recurs once per level
+  decodeNesting nesting;
+
   int cid = 0;
   decode(&cid, in);
 

--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -2856,6 +2856,10 @@ MonoTypePtr decodeTExpr(const bytes& in, unsigned int* n) {
 }
 
 MonoTypePtr decodeFrom(const bytes& in, unsigned int* n) {
+  // every nested type is decoded through here, so this is where the nesting a
+  // description describes is bounded
+  decodeNesting nesting;
+
   switch (read<int>(in, n)) {
   case Prim::type_case_id:       return decodePrim(in, n);
   case OpaquePtr::type_case_id:  return decodeOpaquePtr(in, n);

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -457,3 +457,66 @@ TEST(TypeInf, TypeApplicationReductionIsBounded) {
   MonoTypePtr ident = Prim::make("id", TAbs::make(str::strings("x"), tvar("x")));
   EXPECT_TRUE(show(repType(TApp::make(ident, list(primty("int"))))) == "int");
 }
+
+TEST(TypeInf, DecodeRejectsDeeplyNestedDescriptions) {
+  // A type description nests as deeply as its bytes say, and the decoder recurs
+  // once per level. The bytes are untrusted (a file, or a peer on the RPC path),
+  // and nothing in them bounds that nesting, so a description that is merely
+  // deep -- not malformed, not diverging -- used to run the stack out inside
+  // decode(). Here it is rejected instead.
+  //
+  // The nesting can be written out directly: an array type is its tag followed
+  // by its element type, so a run of array tags is a run of nesting levels. The
+  // run below is never terminated, which doesn't matter -- the bound is reached
+  // long before the decoder would ask what the innermost element type is.
+  auto arrayNest = [](size_t levels) {
+    std::vector<unsigned char> bs;
+    const int tag = Array::type_case_id;
+    const auto* b = reinterpret_cast<const unsigned char*>(&tag);
+    for (size_t i = 0; i < levels; ++i) {
+      bs.insert(bs.end(), b, b + sizeof(tag));
+    }
+    return bs;
+  };
+
+  std::string msg;
+  try {
+    decode(arrayNest(200000));
+  } catch (const std::exception& ex) {
+    msg = ex.what();
+  }
+  EXPECT_TRUE(msg.find("nests more than") != std::string::npos);
+
+  // an expression description is bounded the same way, through the same guard:
+  // this is the decoder the type decoder calls for a TExpr
+  ExprPtr deep(new Unit(LexicalAnnotation::null()));
+  for (size_t i = 0; i < 4000; ++i) {
+    deep = ExprPtr(new App(deep, list(ExprPtr(new Unit(LexicalAnnotation::null()))), LexicalAnnotation::null()));
+  }
+  std::vector<uint8_t> denc;
+  encode(deep, &denc);
+
+  std::string emsg;
+  try {
+    ExprPtr rt;
+    decode(denc, &rt);
+  } catch (const std::exception& ex) {
+    emsg = ex.what();
+  }
+  EXPECT_TRUE(emsg.find("nests more than") != std::string::npos);
+
+  // ordinary descriptions are nowhere near the bound and round-trip as before,
+  // including nesting deep enough to be unusual but still sane
+  MonoTypePtr ty = tuplety(list(primty("int"), arrayty(primty("char")), tvar("elephant")));
+  std::vector<unsigned char> enc;
+  encode(ty, &enc);
+  EXPECT_TRUE(show(decode(enc)) == show(ty));
+
+  MonoTypePtr nested = primty("int");
+  for (size_t i = 0; i < 100; ++i) {
+    nested = arrayty(nested);
+  }
+  std::vector<unsigned char> nenc;
+  encode(nested, &nenc);
+  EXPECT_TRUE(show(decode(nenc)) == show(nested));
+}

--- a/test/TypeInf.C
+++ b/test/TypeInf.C
@@ -473,15 +473,29 @@ TEST(TypeInf, DecodeRejectsDeeplyNestedDescriptions) {
     std::vector<unsigned char> bs;
     const int tag = Array::type_case_id;
     const auto* b = reinterpret_cast<const unsigned char*>(&tag);
+    bs.reserve(levels * sizeof(tag));
     for (size_t i = 0; i < levels; ++i) {
       bs.insert(bs.end(), b, b + sizeof(tag));
     }
     return bs;
   };
 
+  // one level past the bound is enough to be rejected, and the depths here are
+  // written in terms of the bound so that they still say what they mean if it
+  // is ever retuned
   std::string msg;
   try {
-    decode(arrayNest(200000));
+    decode(arrayNest(maxDecodeNesting + 1));
+  } catch (const std::exception& ex) {
+    msg = ex.what();
+  }
+  EXPECT_TRUE(msg.find("nests more than") != std::string::npos);
+
+  // however deep it goes past that, the answer is the same rejection rather
+  // than a deeper walk
+  msg = "";
+  try {
+    decode(arrayNest(100 * maxDecodeNesting));
   } catch (const std::exception& ex) {
     msg = ex.what();
   }
@@ -490,7 +504,7 @@ TEST(TypeInf, DecodeRejectsDeeplyNestedDescriptions) {
   // an expression description is bounded the same way, through the same guard:
   // this is the decoder the type decoder calls for a TExpr
   ExprPtr deep(new Unit(LexicalAnnotation::null()));
-  for (size_t i = 0; i < 4000; ++i) {
+  for (size_t i = 0; i < maxDecodeNesting + 1; ++i) {
     deep = ExprPtr(new App(deep, list(ExprPtr(new Unit(LexicalAnnotation::null()))), LexicalAnnotation::null()));
   }
   std::vector<uint8_t> denc;
@@ -512,8 +526,11 @@ TEST(TypeInf, DecodeRejectsDeeplyNestedDescriptions) {
   encode(ty, &enc);
   EXPECT_TRUE(show(decode(enc)) == show(ty));
 
+  // and the boundary itself is where it says it is: an array wrapped one level
+  // short of the bound is a description of exactly maxDecodeNesting levels --
+  // the deepest the decoder accepts -- and it round-trips
   MonoTypePtr nested = primty("int");
-  for (size_t i = 0; i < 100; ++i) {
+  for (size_t i = 0; i < maxDecodeNesting - 1; ++i) {
     nested = arrayty(nested);
   }
   std::vector<unsigned char> nenc;


### PR DESCRIPTION
A type description nests as deeply as its bytes say it does, and the decoder recurs once per level — `decodeFrom` → `decodeArr`/`decodeTApp`/`decodeRecord`/… → `decodeFrom`. Nothing bounds that, and the bytes are untrusted: they are read from a structured data file, or handed over by a peer on the RPC path before that peer is trusted (see [SECURITY.md](SECURITY.md)). So a description that is merely *deep* — neither malformed nor diverging — runs the stack out inside `hobbes::decode()`.

Measured with an `-O2` build on an 8MB stack, decoding a left-nested chain of `TApp`s:

| nesting | encoded bytes | result |
|---|---|---|
| 50,000 | ~1.4 MB | decodes |
| 70,000 | ~2.0 MB | **SIGSEGV inside `decode`** |

The instrumented build OSS-Fuzz runs `fuzz-type-decode` with, whose frames are several times larger, crosses that at a correspondingly smaller input.

The expression decoder has the same shape — `decode(ExprPtr*, std::istream&)` recurs per level — and the type decoder reaches it through `decodeTExpr`, so a type description can carry a deeply nested expression into the same crash.

## The fix

Both decoders take a `decodeNesting` guard at each level, bounding nesting at `maxDecodeNesting` (2000) and throwing past it. The guard lives with the codec in `util/codec.H` and counts levels in a `thread_local`, so the two decoders share one bound — a description that alternates between them can't spend 2000 levels in each.

The bound sits above the nesting the compiler itself will build, so anything hobbes produces still round-trips, and far below what the stack holds in an instrumented build. That margin is the point: everything that walks a decoded value afterwards — reduction, sizing, printing, and its destructor — recurs through the same nesting, so bounding it at the decoder keeps all of them safe too.

## Provenance

Old bug, not a short-lived regression: neither decoder has ever bounded nesting, so every release is affected. It became reachable by a fuzzer when `fuzz-type-decode` was added.

Found while checking a review comment on #539, which observed that `decodeTApp` recurses without a depth limit. That PR's own reduction recursion is bounded by the step budget it shares (verified against a 100,000-level chain: it rejects rather than overflowing); this is the separate defect that comment describes.

## Testing

`TypeInf/DecodeRejectsDeeplyNestedDescriptions` covers both decoders:

- a run of 200,000 array tags written out directly as bytes — an array type is its tag followed by its element type, so a run of tags is a run of nesting levels;
- an encoded 4,000-level expression;

each rejected with the nesting error rather than crashing, while ordinary descriptions — including a hundred levels of nesting — still round-trip. Verified against the reproducer above: the 100,000-level chain that segfaulted now throws `Encoded data nests more than 2000 levels deep`.

Full `hobbes-test` suite passes, as do all 133 rosetta examples.
