### PR TITLE
Pin the LLVM installer both CI paths fetch

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -9,13 +9,38 @@ FROM gcr.io/oss-fuzz-base/base-builder:v1
 # development package. 18 is covered by the build matrix in build.yml.
 ENV HOBBES_LLVM_VERSION=18
 
+# apt.llvm.org publishes an installer that adds its apt repository. Fetching it
+# from that address runs whatever the site serves at build time; this pins the
+# revision and checks the script against its hash before running it, so the
+# build installs the compiler the same way every time (this is also what
+# OpenSSF Scorecard's pinned-dependencies check asks for).
+ENV LLVM_SH_COMMIT=6dc0d1ad7de83d0782731687fd555a7859b4da58
+ENV LLVM_SH_SHA256=03878e08f47b66cc95bc4b544b0db3c6d9ce8d60e6cf2492ae357984330a9eae
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         cmake make python3 zip \
         zlib1g-dev libncurses-dev libzstd-dev libreadline-dev \
-        wget gnupg lsb-release software-properties-common && \
-    wget -qO- https://apt.llvm.org/llvm.sh | bash -s -- $HOBBES_LLVM_VERSION && \
-    apt-get install -y --no-install-recommends llvm-$HOBBES_LLVM_VERSION-dev && \
+        wget gnupg lsb-release software-properties-common
+
+RUN wget -q -O /tmp/llvm.sh \
+      "https://raw.githubusercontent.com/opencollab/llvm-jenkins.debian.net/${LLVM_SH_COMMIT}/llvm.sh" && \
+    echo "${LLVM_SH_SHA256}  /tmp/llvm.sh" | sha256sum -c -
+
+# The installer decides whether this distribution is supported by asking
+# apt.llvm.org for its repository index, and reports a request that did not
+# come back as an unsupported distribution -- so a single dropped request fails
+# the build with a message about the distribution rather than about the
+# network. Retry before believing it.
+RUN for i in 1 2 3; do \
+      if bash /tmp/llvm.sh "$HOBBES_LLVM_VERSION"; then exit 0; fi; \
+      echo "llvm.sh failed (attempt $i), retrying"; \
+      sleep 15; \
+    done; \
+    exit 1
+
+RUN apt-get install -y --no-install-recommends llvm-$HOBBES_LLVM_VERSION-dev && \
+    rm -f /tmp/llvm.sh && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . $SRC/hobbes

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -17,29 +17,30 @@ ENV HOBBES_LLVM_VERSION=18
 ENV LLVM_SH_COMMIT=6dc0d1ad7de83d0782731687fd555a7859b4da58
 ENV LLVM_SH_SHA256=03878e08f47b66cc95bc4b544b0db3c6d9ce8d60e6cf2492ae357984330a9eae
 
+# One layer, so that the apt indexes this writes are removed by the cleanup at
+# the end of it rather than being kept in a layer the cleanup cannot reach.
+#
+# The retry is around the installer: it decides whether this distribution is
+# supported by asking apt.llvm.org for its repository index, and reports a
+# request that did not come back as an unsupported distribution -- so a single
+# dropped request fails the build with a message about the distribution rather
+# than about the network. The subshell leaves with the installer's success, or
+# fails the layer once three attempts have not come back.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         cmake make python3 zip \
         zlib1g-dev libncurses-dev libzstd-dev libreadline-dev \
-        wget gnupg lsb-release software-properties-common
-
-RUN wget -q -O /tmp/llvm.sh \
+        wget gnupg lsb-release software-properties-common && \
+    wget -q -O /tmp/llvm.sh \
       "https://raw.githubusercontent.com/opencollab/llvm-jenkins.debian.net/${LLVM_SH_COMMIT}/llvm.sh" && \
-    echo "${LLVM_SH_SHA256}  /tmp/llvm.sh" | sha256sum -c -
-
-# The installer decides whether this distribution is supported by asking
-# apt.llvm.org for its repository index, and reports a request that did not
-# come back as an unsupported distribution -- so a single dropped request fails
-# the build with a message about the distribution rather than about the
-# network. Retry before believing it.
-RUN for i in 1 2 3; do \
-      if bash /tmp/llvm.sh "$HOBBES_LLVM_VERSION"; then exit 0; fi; \
-      echo "llvm.sh failed (attempt $i), retrying"; \
-      sleep 15; \
-    done; \
-    exit 1
-
-RUN apt-get install -y --no-install-recommends llvm-$HOBBES_LLVM_VERSION-dev && \
+    echo "${LLVM_SH_SHA256}  /tmp/llvm.sh" | sha256sum -c - && \
+    ( for i in 1 2 3; do \
+        bash /tmp/llvm.sh "$HOBBES_LLVM_VERSION" && exit 0; \
+        echo "llvm.sh failed (attempt $i), retrying"; \
+        sleep 15; \
+      done; \
+      exit 1 ) && \
+    apt-get install -y --no-install-recommends llvm-$HOBBES_LLVM_VERSION-dev && \
     rm -f /tmp/llvm.sh && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install LLVM 22 from apt.llvm.org
+        env:
+          # the installer that adds apt.llvm.org's repository, pinned to a
+          # revision and checked against its hash rather than run as whatever
+          # the site serves at the time (see .clusterfuzzlite/Dockerfile, which
+          # installs LLVM the same way)
+          LLVM_SH_COMMIT: 6dc0d1ad7de83d0782731687fd555a7859b4da58
+          LLVM_SH_SHA256: 03878e08f47b66cc95bc4b544b0db3c6d9ce8d60e6cf2492ae357984330a9eae
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update
@@ -183,7 +190,20 @@ jobs:
             cmake make python3 \
             libncurses-dev zlib1g-dev libreadline-dev libzstd-dev \
             wget gnupg lsb-release software-properties-common
-          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 22
+          wget -q -O /tmp/llvm.sh \
+            "https://raw.githubusercontent.com/opencollab/llvm-jenkins.debian.net/${LLVM_SH_COMMIT}/llvm.sh"
+          echo "${LLVM_SH_SHA256}  /tmp/llvm.sh" | sha256sum -c -
+          # the installer asks apt.llvm.org for its repository index to decide
+          # whether this distribution is supported, and reports a request that
+          # did not come back as an unsupported distribution, so retry before
+          # believing it
+          ok=
+          for i in 1 2 3; do
+            if sudo bash /tmp/llvm.sh 22; then ok=1; break; fi
+            echo "llvm.sh failed (attempt $i), retrying"
+            sleep 15
+          done
+          [ -n "$ok" ]
           sudo apt-get install -y --no-install-recommends \
             clang-22 llvm-22-dev libclang-22-dev
       - name: Configure


### PR DESCRIPTION
Two builds install LLVM by piping apt.llvm.org's installer straight into a shell:

```
.clusterfuzzlite/Dockerfile   wget -qO- https://apt.llvm.org/llvm.sh | bash -s -- 18
.github/workflows/build.yml   wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 22
```

Whatever that address serves at the moment of the build is what runs as root, with no record of which version ran. Everything else in these workflows is pinned — actions by commit hash, the base image by tag — and this is the one dependency that isn't. It's also what OpenSSF Scorecard's pinned-dependencies check asks about.

## The change

Fetch the script from the revision it's generated from — [`opencollab/llvm-jenkins.debian.net@6dc0d1a`](https://github.com/opencollab/llvm-jenkins.debian.net/blob/6dc0d1ad7de83d0782731687fd555a7859b4da58/llvm.sh) — and check it against its SHA-256 before running it. Both paths then install the compiler the same way on every build, and a change to the installer arrives as a checksum failure rather than as new code running unnoticed.

I checked that the pinned revision is byte-identical to what the unpinned address serves today, so this changes what is *guaranteed*, not what gets installed.

## Also: the installer is retried

It decides whether a distribution is supported by asking apt.llvm.org for its repository index, and reports a request that didn't come back as an unsupported distribution:

```
+ wget -q --method=HEAD --timeout=15 --tries=3 https://apt.llvm.org/focal/
+ error 'Distribution 'ubuntu' in version '20.04.6 LTS (Focal Fossa)' is not supported by this script.' 2
```

That failed the ClusterFuzzLite build on #544, while the same build passed six minutes later on another branch — so a single dropped request fails a pull request with a message about the distribution rather than about the network. Both paths now make three attempts, and still fail if all three do.

Pinning alone would not have fixed that, and retrying alone would not have pinned anything; the two changes are here together because they touch the same three lines.

## Not covered here

The OSS-Fuzz image (`projects/hobbes/Dockerfile` in google/oss-fuzz) installs LLVM the same way and wants the same change. It lives in that repository, so it isn't part of this PR.

## Testing

- The `fuzz` check on this PR builds the very Dockerfile this changes, and `apt-llvm22-build` exercises the workflow path — so CI here is the test.
- The retry loops were checked in both shells that run them (`bash -e` for the workflow step, `sh` for the `RUN`): each exits 0 when an attempt succeeds and non-zero when all three fail, rather than passing on a loop that fell through.
