### PR TITLE
Reject a regex whose capturing group name is never closed

### DIFF
--- a/fuzz/corpus/parse-expr/regex_capture_group.hob
+++ b/fuzz/corpus/parse-expr/regex_capture_group.hob
@@ -1,0 +1,1 @@
+match "aaab" with | '(?<pre>a+)b' -> length(pre) | _ -> 0L

--- a/lib/hobbes/lang/pat/regex.C
+++ b/lib/hobbes/lang/pat/regex.C
@@ -239,6 +239,14 @@ DCharset readCharset(const std::string& x, size_t i) {
     if (c0 == ']') {
       return r;
     } else if (c0 == '\\') {
+      // c1 is the escaped character, and the increment below steps over it --
+      // but when the backslash is the last character there is no c1 (the read
+      // above substituted a nul for it), and stepping over it lands one past
+      // the end. diffRegex rejects a trailing escape outside a charset; do the
+      // same within one rather than returning a position that cannot be read.
+      if (r.first == x.size()) {
+        throw std::runtime_error("Unexpected end in regex (expecting escape code)");
+      }
       unescapeInto(c1, &r.second);
       ++r.first;
     } else if (c1 == '-' && (r.first+1) < x.size()) {
@@ -291,6 +299,19 @@ DRegex seqR(const RegexPtr& lhs, const RegexPtr& c, const std::string& x, size_t
 }
 
 DRegex diffRegex(const RegexPtr& lhs, const std::string& x, size_t i, TermBudget* tb) {
+  // a position past the end is a step this function's own cases got wrong, not
+  // something an input can ask for -- each of them advances at most one past
+  // the character it consumed. Nothing downstream rechecks, though: reading
+  // from out there does not stop, it walks further off the end for as many
+  // terms as the budget allows (OSS-Fuzz testcase 4831270021693440 read ~1,000
+  // bytes past a 3-byte buffer that way). Two steps did get it wrong -- an
+  // unterminated capturing group name below, and a trailing escape in
+  // readCharset -- and both now reject instead. This is what keeps a third
+  // from being an out-of-bounds read rather than an error.
+  if (i > x.size()) {
+    throw std::runtime_error("Internal error: regex read position is past the end of the regex");
+  }
+
   if (i == x.size()) {
     return DRegex(i, lhs);
   } else {
@@ -320,6 +341,14 @@ DRegex diffRegex(const RegexPtr& lhs, const std::string& x, size_t i, TermBudget
         }
         size_t j = k;
         while (j < x.size() && x[j] != ed) { ++j; }
+
+        // the scan above stops either on the closing delimiter or on the end of
+        // the regex. Only the first is a group name: the second means there is
+        // no delimiter to resume after, and reading on from it steps past the
+        // end (`i` becomes x.size(), and the recursion below starts at i+1).
+        if (j == x.size()) {
+          throw std::runtime_error(std::string("Unexpected end in regex (expecting '") + static_cast<char>(ed) + "' to close a capturing group name)");
+        }
 
         b = x.substr(k, j-k);
         i = j;

--- a/test/Matching.C
+++ b/test/Matching.C
@@ -470,6 +470,49 @@ TEST(Matching, deeplyNestedRegexIsRejected) {
                        std::exception, "regex is too complex to compile");
 }
 
+// A capturing group name runs to a closing '>' or '\''. The scan for it used
+// to stop just as happily at the end of the regex, and reading resumed one
+// character past where that delimiter would have been -- out of the string.
+// Nothing downstream rechecks the read position, so the walk did not stop
+// there: it ran further out for as many terms as the budget allowed, ~1,000
+// bytes past a 3-byte buffer (OSS-Fuzz 4831270021693440, reported by ASan as a
+// stack-buffer-overflow in diffRegex, from a 5-byte input).
+TEST(Matching, unterminatedCaptureGroupNameIsRejected) {
+  EXPECT_EXCEPTION_MSG(c().readExpr("'(?<'"), std::exception,
+                       "capturing group name");
+  EXPECT_EXCEPTION_MSG(c().readExpr("'(?P<abc'"), std::exception,
+                       "capturing group name");
+  EXPECT_EXCEPTION_MSG(c().readExpr("'(?'"), std::exception,
+                       "capturing group name");
+
+  // the rest are reached through parseRegex rather than through a regex
+  // literal: it is public API, and the lexer will not hand it either a body
+  // whose group name is quote-delimited (a bare ' closes the literal) or one
+  // ending in a lone backslash
+  EXPECT_EXCEPTION_MSG(parseRegex("(?'abc"), std::exception,
+                       "capturing group name");
+
+  // a trailing escape inside a character class stepped past the end the same
+  // way, one function over in readCharset
+  EXPECT_EXCEPTION_MSG(parseRegex("[\\"), std::exception,
+                       "expecting escape code");
+
+  // named groups and character classes that are properly closed still read
+  EXPECT_TRUE(parseRegex("(?<n>a)") != nullptr);
+  EXPECT_TRUE(parseRegex("(?'n'a)") != nullptr);
+  EXPECT_TRUE(parseRegex("(?P<n>a)") != nullptr);
+  EXPECT_TRUE(parseRegex("[a-c\\]]") != nullptr);
+}
+
+TEST(Matching, capturedGroupsStillBind) {
+  // the delimiter scan is what capture binding runs on, so check it still
+  // binds what it captures
+  auto f = c().compileFn<long(const std::string &)>(
+      "x", "match x with | '(?<pre>a+)b' -> length(pre) | _ -> 0L");
+  EXPECT_EQ(f("aaab"), 3L);
+  EXPECT_EQ(f("zzz"), 0L);
+}
+
 TEST(Matching, regexesUnderTheTermLimitStillCompile) {
   const size_t n = 500;
   auto f = c().compileFn<bool(const std::string &)>(


### PR DESCRIPTION
Fixes the stack overread OSS-Fuzz reports as issue 549752447 (testcase 4831270021693440), which still reproduces on `main`.

### The bug

```
Crash Type: Stack-buffer-overflow READ 1
Crash State:
  hobbes::diffRegex
  hobbes::seqR
  hobbes::diffRegex
```

The minimized input is five bytes: `'(?<'`.

A capturing group may be named — `(?<name>E)` or `(?'name'E)` — and `diffRegex` reads that name by scanning for the closing delimiter. The scan stops either on the delimiter or on the end of the regex, and only the first was distinguished: reading resumed from where the delimiter would have been, which for the second is the end, and the group body was then read from one past that.

Nothing downstream rechecks the read position, so the walk did not stop out there. It kept going a term at a time until the term budget from 89b2b76 stopped it — a three byte regex read about a thousand bytes past its end. That buffer is a `std::string`'s small-string buffer on the stack, hence *stack*-buffer-overflow, and what the parser does next depends on whatever is in those bytes: the same input produced `Unexpected end in regex (expecting ']')` in one build here and `Expected capturing group name delimited as 'name' or <name>` in another.

An old bug, not a regression: named capturing groups have been read this way since they were added, and a fuzzer could reach it once `fuzz-parse-expr` existed.

### The fix

Three changes, all in `lib/hobbes/lang/pat/regex.C`:

1. **An unterminated group name is rejected**, the way the sibling check just above it already rejects a group name with no delimiter at all.
2. **`readCharset` had the same off-by-one** one function over: a backslash as the last character of a charset has nothing to escape, and stepping over the character that is not there returned a position one past the end, which `returnR` then read from. `diffRegex` rejects a trailing escape outside a charset; this does the same within one. The lexer's regex-literal rule cannot produce a body ending in a lone backslash, so that path is reached through `parseRegex`, which is public API.
3. **`diffRegex` rejects a read position past the end on entry.** What made either of the above an overread rather than a bad parse is that nothing noticed the position had escaped; a third such step is now an error instead of an out-of-bounds read.

### Verification

Built with ASan+UBSan on Linux (clang 18, `-DUSE_ASAN_AND_UBSAN=ON`), which reproduces the report exactly — `regex.C:300:42`, with the stack above. The same build is clean on the reproducer with this change, as is a five minute ASan fuzz run over the corpus.

The full test suite passes. `test/Matching.C` gains coverage of the rejection through both `readExpr` and `parseRegex`, and of properly closed groups and character classes still reading and still binding what they capture — `unterminatedCaptureGroupNameIsRejected` fails on an unfixed build. A seed with a named capturing group goes into the `parse-expr` corpus, which had nothing exercising the delimiter scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rGT4C394qeh2DBQhqy3Tb
