### PR TITLE
Compact the type memo periodically in the decoder harnesses

### DIFF
--- a/fuzz/fuzz_fregion_reader.C
+++ b/fuzz/fuzz_fregion_reader.C
@@ -8,8 +8,16 @@
 //
 // libFuzzer hands us a byte buffer while the reader wants a file path, so
 // each input is written to one scratch file that is rewritten per iteration.
+//
+// The type descriptions in those environment records go through the same
+// decoder fuzz-type-decode exercises, and so into the same process-wide type
+// memo, which keeps every type it has ever interned until compactMTypeMemory()
+// is called. The memo is compacted every few dozen inputs for the reason given
+// in fuzz_type_decode.C: otherwise a campaign that mutates type descriptions
+// grows by every distinct one it has read.
 
 #include <hobbes/fregion.H>
+#include <hobbes/lang/type.H>
 
 #include <cstddef>
 #include <cstdint>
@@ -22,6 +30,16 @@
 #include <unistd.h>
 
 namespace {
+
+const unsigned inputsPerCompaction = 64;
+
+void compactTypeMemoPeriodically() {
+  static unsigned sinceCompaction = 0;
+  if (++sinceCompaction >= inputsPerCompaction) {
+    sinceCompaction = 0;
+    hobbes::compactMTypeMemory();
+  }
+}
 
 const std::string& scratchPath() {
   static const std::string p = [] {
@@ -60,5 +78,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   } catch (const std::exception&) {
     // rejecting a malformed image is the expected behavior
   }
+  compactTypeMemoPeriodically();
   return 0;
 }

--- a/fuzz/fuzz_type_decode.C
+++ b/fuzz/fuzz_type_decode.C
@@ -4,6 +4,21 @@
 // (ipc/net.C), where it runs on bytes from an unauthenticated peer before any
 // expression is accepted. A malformed or truncated buffer must throw, never
 // read out of bounds.
+//
+// Decoding is not free of side effects: every type it builds is interned in
+// the process-wide type memo (tctorMaps in lang/type.C), which holds a
+// reference of its own, and only compactMTypeMemory() lets go of the entries
+// nothing else refers to. A decoder that reads a fresh type per input and
+// never compacts therefore grows by every type it has ever read -- measured
+// at about 380 bytes per distinct type -- and a campaign runs the process out
+// of memory with no one input to blame. That is what OSS-Fuzz testcase
+// 6130308650172416 reports: an out-of-memory in this target whose reproducer
+// is empty.
+//
+// Compacting keeps the memo at its resting size. It costs about as much as a
+// decode does, so it is done every few dozen inputs rather than every one:
+// what accumulates in between is a few dozen types, and the fuzzer keeps its
+// throughput.
 
 #include <hobbes/lang/type.H>
 
@@ -11,11 +26,26 @@
 #include <cstdint>
 #include <exception>
 
+namespace {
+
+const unsigned inputsPerCompaction = 64;
+
+void compactTypeMemoPeriodically() {
+  static unsigned sinceCompaction = 0;
+  if (++sinceCompaction >= inputsPerCompaction) {
+    sinceCompaction = 0;
+    hobbes::compactMTypeMemory();
+  }
+}
+
+} // namespace
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   try {
     hobbes::decode(data, data + size);
   } catch (const std::exception&) {
     // rejecting malformed input is the expected behavior
   }
+  compactTypeMemoPeriodically();
   return 0;
 }


### PR DESCRIPTION
Fixes the out-of-memory OSS-Fuzz reports against `fuzz-type-decode` as testcase 6130308650172416 — the one whose reproducer is **zero bytes**. A crash with no input is a crash no input causes; this is the harness accumulating.

### The bug

`hobbes::decode` interns every type it builds in the process-wide type memo (`tctorMaps` in `lang/type.C`). The memo holds a reference of its own to each entry, and only `compactMTypeMemory()` releases the entries nothing else refers to. It is called from exactly one place in the tree (`eval/search.C`); the decoder is not it. So a process that decodes a fresh type per input and never compacts keeps every type it has ever read.

Measured with a probe decoding 20,000 distinct record types:

| | |
|---|---|
| the same type, 20,000× | +16 KB (interned once, by value) |
| a fresh type each time | **+7,452 KB** — 381 bytes per type, retained |
| …then `compactMTypeMemory()` | −7,164 KB (reclaimed: nothing held them) |
| fresh types, compacting each | **+0 KB** |

A fuzzer mutates, so nearly every input is a fresh type, and the memo grows by every one until the process is out of memory.

### The fix

Compact the memo every 64 inputs, in **both** harnesses that decode types: `fuzz-type-decode` directly, and `fuzz-fregion-reader` through the type descriptions in a file's environment records (`db/file.C`), which go through the same decoder into the same memo. The second has no report against it yet; it is the same mechanism and would produce the same one.

Every 64 rather than every input because a compaction costs about as much as a decode: per input it halved the fuzzer's throughput (23k → 13k exec/s), every 64 it does not show (21k), and what accumulates in between is a few dozen types.

### Verification

Fuzzing `fuzz-type-decode` for 90 s from an empty corpus, unsanitized so RSS is an honest read of the heap:

| | 262k inputs | 1M | ~2M |
|---|---|---|---|
| before | 69 MB | 92 MB | 128 MB — climbing |
| after | 74 MB | 74 MB | 74 MB — **flat** |

The fregion-reader corpus replays cleanly.

### Worth knowing

This bounds the harnesses. The memo's behaviour is the library's: the RPC layer decodes peer-supplied type descriptions through the same path (`ipc/net.C`) without compacting either, so a server handed many distinct type descriptions by a peer grows the same way. Left as-is here — a `compactMTypeMemory()` call in the RPC loop is a one-liner, but it belongs with whoever owns that code's performance expectations. Happy to open it as an issue or a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rGT4C394qeh2DBQhqy3Tb
