### PR TITLE
Keep the parse-expr fuzz harness from growing without bound

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -50,10 +50,13 @@ Notes per harness:
   `hog` or the `Storage` tests. Malformed page metadata can make the reader
   attempt large mappings, so keep the default `-rss_limit_mb` in place, and a
   malformed page table can make it spin, so keep `-timeout` in place too.
-* **fuzz-parse-expr** — seeds in `corpus/parse-expr/`. The compiler instance
-  is constructed once and reused; parsing allocates from arenas that are not
-  reclaimed per-iteration, so run with `-detect_leaks=0` and let
-  `-rss_limit_mb` restart the process as needed.
+* **fuzz-parse-expr** — seeds in `corpus/parse-expr/`. Reading a regex
+  literal compiles a matcher into the compiler and interns its types in the
+  process-wide type memo, and nothing releases either, so a run that reads
+  regexes grows without bound unless the harness intervenes: it compacts the
+  memo every 64 inputs and replaces the compiler every 1024 (see the harness
+  for the figures). Parsing also allocates from arenas that are not reclaimed
+  per-iteration, so run with `-detect_leaks=0`.
 
 Replaying a reproducer (works in both build modes):
 

--- a/fuzz/fuzz_parse_expr.C
+++ b/fuzz/fuzz_parse_expr.C
@@ -2,21 +2,79 @@
 //
 // Evaluating Hobbes code is running trusted native code, but *reading* source
 // text sits on the near side of that trust boundary: lexing and parsing must
-// be safe on arbitrary bytes. This harness only parses -- nothing is
-// compiled or evaluated.
+// be safe on arbitrary bytes. Nothing here is evaluated.
+//
+// Reading is not entirely free of compilation, though, and the difference
+// shows up over a campaign rather than on any one input. A regex literal is
+// turned into a matching function where it is read: makeRegexFn determinizes
+// it and defines the result in the compiler under a fresh name, and the types
+// that takes are interned in the process-wide type memo (tctorMaps in
+// lang/type.C), which holds a reference of its own to each of them. Nothing
+// removes the definition, and only compactMTypeMemory() lets go of the types.
+// So a `cc` reused across inputs, with the memo left alone, grows by every
+// regex it has ever read: measured at about 168KB per read of the twenty
+// character regex in OSS-Fuzz testcase 4850385077207040 -- roughly half of
+// it in the memo and half in the compiler -- against no growth that can be
+// measured at all for an input with no regex in it. Left alone, a campaign
+// feeding regexes runs the process out of memory. That is what the testcase
+// reports: an out-of-memory that ClusterFuzz could not minimize, because no
+// single input causes it.
+//
+// So two things are done periodically, one for each half. The type memo is
+// compacted every few dozen inputs, as the decoder harnesses do; that gives
+// back the memo's half and costs about as much as a parse. The compiler is
+// replaced every thousand or so; that gives back its half, and costs the
+// fraction of a second it takes to build one, amortised over enough inputs
+// not to show. Neither alone is enough: each leaves the other half growing
+// without bound. Counts of inputs are a coarse stand-in for how much has
+// accumulated, but a portable and predictable one -- resident size is not,
+// because freeing memory does not hand it back to the operating system, so a
+// harness that watched RSS rebuilt the compiler on every input once it first
+// went over.
 
 #include <hobbes/hobbes.H>
 
 #include <cstddef>
 #include <cstdint>
 #include <exception>
+#include <memory>
 #include <string>
 
 namespace {
 
-hobbes::cc& compiler() {
-  static hobbes::cc c;
+const unsigned long inputsPerCompaction = 64;
+const unsigned long inputsPerCompiler   = 1024;
+
+// The first compiler is built in the initializer rather than on first use.
+// Constructing a cc also constructs the LLVM statics it depends on, and at
+// exit everything static is destroyed in reverse order of construction: a slot
+// that was registered empty and filled afterwards would be destroyed after
+// those statics, and the cc inside it would tear down against an LLVM context
+// that was already gone.
+std::unique_ptr<hobbes::cc>& compilerSlot() {
+  static std::unique_ptr<hobbes::cc> c(new hobbes::cc());
   return c;
+}
+
+hobbes::cc& compiler() {
+  std::unique_ptr<hobbes::cc>& c = compilerSlot();
+  if (!c) {
+    c = std::unique_ptr<hobbes::cc>(new hobbes::cc());
+  }
+  return *c;
+}
+
+void reclaimPeriodically() {
+  static unsigned long read = 0;
+  ++read;
+  if (read % inputsPerCompiler == 0) {
+    compilerSlot().reset();
+  }
+  if (read % inputsPerCompaction == 0) {
+    // after the compiler is let go, where that happened, so that the types
+    // only it was holding are released too
+    hobbes::compactMTypeMemory();
+  }
 }
 
 } // namespace
@@ -28,5 +86,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   } catch (const std::exception&) {
     // rejecting malformed source is the expected behavior
   }
+  reclaimPeriodically();
   return 0;
 }


### PR DESCRIPTION
Fixes the out-of-memory OSS-Fuzz reports against `fuzz-parse-expr` as testcase 4850385077207040 — no minimized reproducer, a 51-byte unminimized one that is a plain syntax error. ClusterFuzz could not minimize it because no single input causes the failure: it is the harness, accumulating.

### The bug

Every read of that input leaves the process ~168 KB larger, for good. The harness's own comment says "this harness only parses — nothing is compiled or evaluated"; the second half is true, the first is not quite. A regex literal is turned into a matching function **where it is read**: `makeRegexFn` determinizes it and defines the result in the compiler under a fresh name (`.regex.<freshName()>`), and the types that takes are interned in the process-wide type memo (`tctorMaps`), which holds a reference of its own to each. Nothing removes the definition, and only `compactMTypeMemory()` releases the types.

Retained per `readExpr`, unsanitized:

| input | retained |
|---|---|
| `1+2` | 0 KB |
| `1 +` (syntax error) | 0 KB |
| `'abc'` | 31 KB |
| `'a.b.c.d.e'` | 108 KB |
| the testcase | **168 KB** |

Nothing but regex literals retains anything. Where it goes, in cycles of 100 reads of the testcase:

| | |
|---|---|
| 100 reads | +17.1 MB |
| `compactMTypeMemory()` | −8.9 MB (the memo's half) |
| destroy the `cc` | −15.2 MB (its half, plus its own) |
| build a new `cc` | +10.1 MB |
| **net per cycle, doing both** | **+0.5 MB** |

Roughly half memo, half compiler — and **neither release alone is enough**. A first version of this change only replaced the compiler, and under ASan on Linux it grew almost as fast as no change at all (2512 MB vs 3169 MB at 8000 reads). That's why the harness now does both.

### The fix

On a count of inputs: compact the type memo every 64 (as #549 does in the decoder harnesses), and replace the compiler every 1024 — a fraction of a second each time, amortised over enough inputs not to show. Counts are coarse but portable and predictable; resident size is neither, since freed memory isn't handed back to the OS, and a version that watched RSS rebuilt the compiler on every input once it first went over.

One detail: the first compiler is built in the slot's **initializer**, not on first use. Constructing a `cc` also constructs the LLVM statics it depends on, and statics are destroyed at exit in reverse order of construction — a slot registered empty and filled later would be destroyed *after* those statics, and the `cc` in it would tear down against an LLVM context already gone. That shape crashed at exit in `LLVMContext::removeModule`; this one exits cleanly, as the original did.

### Verification

Under ASan on Linux, 8000 copies of the testcase, RSS at 1024 / 2048 / 4096 / 8000 inputs:

| | | | | |
|---|---|---|---|---|
| before | 1081 | 1388 | 2001 | 3169 MB — climbing |
| after | 915 | 1071 | 1108 | **1146 MB — levelling off** |

The checked-in corpus replays cleanly. A local 5-minute fuzz run of the new harness found a **pre-existing** stack overflow in `dfaState`'s recursion on a regex within the DFA-state cap — unrelated to this change, being handled separately. README and the harness header updated to say what the harness actually does.

### Worth knowing

This bounds the harness. Both halves of the growth are the library's, and a host that reads regex literals from many distinct sources has the same exposure: the memo half is what #549 also works around; the compiler half — a compiled matcher per regex literal read, never reclaimed — is left as-is, since making them reclaimable is a design change rather than a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rGT4C394qeh2DBQhqy3Tb
