### PR TITLE
Build a regex's DFA with a worklist instead of recursing per state

### DIFF
--- a/lib/hobbes/lang/pat/regex.C
+++ b/lib/hobbes/lang/pat/regex.C
@@ -740,9 +740,10 @@ stateset nfaTransition(const NFA& nfa, const EpsClosure& ec, const stateset& ss,
 // sets of NFA states are mapped to distinct DFA states
 using Nss2Ds = std::map<stateset, state>;
 
-// create a DFA state from a set of NFA states
-// (or if it's already been made, just return the existing state)
-state dfaState(const cc* c, const NFA& nfa, const EpsClosure& ec, Nss2Ds* nss2ds, DFA* dfa, const stateset& ss, RStates* rstates) {
+// the DFA state for a set of NFA states: the one already made for it, or a
+// new one, allocated here and left on the worklist for its transitions to be
+// filled in
+state dfaState(const cc* c, const NFA& nfa, Nss2Ds* nss2ds, DFA* dfa, std::vector<std::pair<state, stateset>>* pending, const stateset& ss) {
   // did we already make this state?  if so, just return it
   auto didIt = nss2ds->find(ss);
   if (didIt != nss2ds->end()) {
@@ -767,37 +768,7 @@ state dfaState(const cc* c, const NFA& nfa, const EpsClosure& ec, Nss2Ds* nss2ds
   }
 
   (*nss2ds)[ss] = result;
-
-  // ok, how can we transition out of here?
-  // for each case, we'll go to a set of NFA states (recursively)
-  for (auto cr : usedCharRanges(nfa, ss)) {
-    auto ns = dfaState(c, nfa, ec, nss2ds, dfa, nfaTransition(nfa, ec, ss, cr), rstates);
-    (*dfa)[result].chars.insert(cr, ns);
-  }
-
-  // our DFA state accepts if any of its NFA states accept
-  // we may have multiple potential matches here, so we should
-  // keep track of every such set so that outer match compilation
-  // can choose the right one
-  for (state s : ss) {
-    auto nr = nfa[s].acc;
-    if (nr != nullResult) {
-      (*dfa)[result].acc = result;
-      (*rstates)[result].insert(nr);
-    }
-  }
-
-  // our DFA state begins/ends subrange recording for each collapsed NFA state
-  for (state s : ss) {
-    for (const auto& b : nfa[s].begins) {
-      (*dfa)[result].begins[b.first].insert(b.second.begin(), b.second.end());
-    }
-    for (const auto& e : nfa[s].ends) {
-      (*dfa)[result].ends[e.first].insert(e.second.begin(), e.second.end());
-    }
-  }
-
-  // that's it, we're done
+  pending->push_back(std::make_pair(result, ss));
   return result;
 }
 
@@ -806,10 +777,56 @@ void disambiguate(const cc* c, const NFA& nfa, DFA* dfa, RStates* rstates) {
   EpsClosure ec;
   findEpsClosure(nfa, &ec);
 
-  // starting from the eps* start state,
-  // follow non-eps transitions to eps* successor states
+  // starting from the eps* start state, follow non-eps transitions to eps*
+  // successor states, making a DFA state for each set of NFA states reached.
+  //
+  // this is a walk over the DFA as it is built, and it is done with an
+  // explicit worklist rather than by recursing into each successor as it is
+  // found: the walk can be as deep as the DFA has states -- a chain of
+  // transitions with no repeats is one frame per state -- and the cap on
+  // state count above bounds how many there are, not how deep a chain of them
+  // goes. A regex well inside that cap ran the stack out this way once its
+  // frames were made large by instrumentation (each carried the sets of NFA
+  // states it was visiting). The order states are made in is not significant
+  // to anything downstream, only that each set of NFA states gets one.
   Nss2Ds nss2ds;
-  dfaState(c, nfa, ec, &nss2ds, dfa, epsState(ec, 0), rstates);
+  std::vector<std::pair<state, stateset>> pending;
+  dfaState(c, nfa, &nss2ds, dfa, &pending, epsState(ec, 0));
+
+  while (!pending.empty()) {
+    const state    result = pending.back().first;
+    const stateset ss     = pending.back().second;
+    pending.pop_back();
+
+    // ok, how can we transition out of here?
+    // for each case, we'll go to a set of NFA states
+    for (auto cr : usedCharRanges(nfa, ss)) {
+      auto ns = dfaState(c, nfa, &nss2ds, dfa, &pending, nfaTransition(nfa, ec, ss, cr));
+      (*dfa)[result].chars.insert(cr, ns);
+    }
+
+    // our DFA state accepts if any of its NFA states accept
+    // we may have multiple potential matches here, so we should
+    // keep track of every such set so that outer match compilation
+    // can choose the right one
+    for (state s : ss) {
+      auto nr = nfa[s].acc;
+      if (nr != nullResult) {
+        (*dfa)[result].acc = result;
+        (*rstates)[result].insert(nr);
+      }
+    }
+
+    // our DFA state begins/ends subrange recording for each collapsed NFA state
+    for (state s : ss) {
+      for (const auto& b : nfa[s].begins) {
+        (*dfa)[result].begins[b.first].insert(b.second.begin(), b.second.end());
+      }
+      for (const auto& e : nfa[s].ends) {
+        (*dfa)[result].ends[e.first].insert(e.second.begin(), e.second.end());
+      }
+    }
+  }
 }
 
 /*****************************

--- a/test/Matching.C
+++ b/test/Matching.C
@@ -4,6 +4,7 @@
 #include <ctime>
 #include <hobbes/hobbes.H>
 #include <hobbes/util/perf.H>
+#include <pthread.h>
 #include <thread>
 
 // compile-time bounds are skipped in sanitized builds, where instrumentation
@@ -497,6 +498,50 @@ TEST(Matching, pathologicalRegexIsRejected) {
 #if !HOBBES_TEST_SKIP_TIMING_BOUNDS
   EXPECT_TRUE(dt < 30L * CLOCKS_PER_SEC);
 #endif
+}
+
+// The cap bounds how many DFA states are built, not how deep the walk that
+// builds them goes: a chain of transitions with no repeats is one state per
+// step, and the construction used to recurse once per step, so a regex within
+// the cap could still be up to 10,000 frames deep. Each frame carried the sets
+// of NFA states being visited, and once instrumentation made them larger that
+// was more stack than a thread has. This regex is from a local fuzz run of an
+// unoptimized UBSan build, where it overflowed the stack in dfaState before
+// reaching the cap; the construction is now a worklist, so the depth of the
+// walk is heap and the only bound that matters is the cap.
+static const char deepChainRegex[] =
+    "match \"a \" with | ' *......++...,..............................@./' -> 1 | _ -> 0";
+
+TEST(Matching, deepDFAChainIsRejectedNotOverflowed) {
+  EXPECT_EXCEPTION_MSG(c().readExpr(deepChainRegex), std::exception,
+                       "regex is too complex to compile");
+}
+
+TEST(Matching, dfaConstructionDoesNotDependOnStackSize) {
+  // the same read on a thread with a 1MB stack: room for the parse and the
+  // rejection, not for ten thousand recursive frames. An unfixed build
+  // overflows here rather than failing the test.
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_setstacksize(&attr, 1024 * 1024);
+
+  std::string outcome;
+  auto body = [](void* p) -> void* {
+    std::string* out = static_cast<std::string*>(p);
+    try {
+      c().readExpr(deepChainRegex);
+      *out = "parsed";
+    } catch (const std::exception& ex) {
+      *out = ex.what();
+    }
+    return nullptr;
+  };
+  pthread_t t;
+  EXPECT_EQ(pthread_create(&t, &attr, body, &outcome), 0);
+  pthread_join(t, nullptr);
+  pthread_attr_destroy(&attr);
+
+  EXPECT_TRUE(outcome.find("regex is too complex to compile") != std::string::npos);
 }
 
 // The cap is what keeps that regex out, but the DFA behind it also has to be


### PR DESCRIPTION
Not an OSS-Fuzz report — this turned up while verifying #550, fuzzing `fuzz-parse-expr` locally in an unoptimized UBSan build — but the cause is structural, so filing it rather than sitting on it.

### The bug

An 80-byte input overflows the stack in `dfaState`:

```
match "a " with | ' *......++...,..............................@./' -> 1 | _ -> 0

UndefinedBehaviorSanitizer: stack-overflow
    #16 hobbes::dfaState(...) regex.C:769
    ... the same frame, past the 256 libFuzzer prints
```

`dfaState` is the subset construction: it makes the DFA state for a set of NFA states, then **recurses** into the DFA state for each set reachable from it. That walk is as deep as the DFA has states along a chain of transitions with no repeats — one frame per state — and each frame holds the sets of NFA states it is visiting. `regexMaxDFAStates` (61fe099) caps how many states are built, and so how deep that chain can go, at 10,000. That was described as bounding the recursion, and it does — 10,000 frames is just more than a thread has once the frames are instrumented, so a regex within the cap overflowed on the way to it.

The regex above needs more than 10,000 states and is rejected for it — now. Before, in that build, it never got as far as the rejection. It does not reproduce in an `-O2` ASan build on Linux, where the frames are small enough; it is the unoptimized/instrumented shape (CI's ASan+UBSan jobs, OSS-Fuzz's builds) where it bites. Old bug: the construction has recursed this way since it was written, and the cap made the depth finite without making it fit.

### The fix

Replace the recursion with an explicit worklist. `dfaState` allocates a state for a set of NFA states it has not seen and queues it; `disambiguate` drains the queue, filling in each state's transitions, accept set and capture markers exactly as the recursive body did. The walk's depth is now on the heap, and the only bound that matters is the cap.

The order states are made in changes (preorder of the recursion → the worklist's), which nothing downstream depends on: states are identified by the set of NFA states they stand for, the start state is still the first one made, and the merge and minimization passes that follow are order-insensitive.

### Verification

Full test suite passes; 133/133 rosetta examples pass; the regex above is rejected with the same error as any other over-cap regex. `test/Matching.C` gains that check, and `dfaConstructionDoesNotDependOnStackSize`, which reads the same regex on a thread with a 1 MB stack — room for the parse and the rejection, not for ten thousand frames. On an unfixed build that test **crashes the process** (a stack-guard fault — SIGBUS, exit 138, on macOS) rather than failing; on the fixed build both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rGT4C394qeh2DBQhqy3Tb
