### PR TITLE
Pin the generators the checked-in parser and lexer are made with

### DIFF
--- a/.github/workflows/pgen.yml
+++ b/.github/workflows/pgen.yml
@@ -1,0 +1,46 @@
+name: "Generated parser"
+
+# hexpr.parse.C, hexpr.parse.H and hexpr.lex.C are checked in, generated from
+# hexpr.y and hexpr.l by the bison and flex versions lib/hobbes/read/pgen/pgen.sh
+# pins. This regenerates them with those versions and fails if the result
+# differs from what is checked in: a change to a grammar file has to come with
+# its regenerated output, and the output has to come from the pinned
+# generators, so that the diff reviewers see is the change and not the
+# generator.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'lib/hobbes/read/pgen/**'
+      - 'include/hobbes/read/pgen/**'
+      - '.github/workflows/pgen.yml'
+  pull_request:
+    paths:
+      - 'lib/hobbes/read/pgen/**'
+      - 'include/hobbes/read/pgen/**'
+      - '.github/workflows/pgen.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  regenerate:
+    # ubuntu-24.04 packages the pinned versions (flex 2.6.4, bison 3.8.2), so
+    # the generators run natively here; pgen.sh checks the versions before it
+    # runs them, and locally it runs the same thing in a container of the same
+    # release
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install the pinned generators
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends bison flex
+          bison --version | head -1
+          flex --version
+      - name: Regenerate
+        run: PGEN_NATIVE=1 lib/hobbes/read/pgen/pgen.sh
+      - name: Compare with the checked-in files
+        run: |
+          git status --short -- lib/hobbes/read/pgen include/hobbes/read/pgen
+          git diff --exit-code -- lib/hobbes/read/pgen include/hobbes/read/pgen

--- a/.github/workflows/pgen.yml
+++ b/.github/workflows/pgen.yml
@@ -25,17 +25,20 @@ permissions:
 
 jobs:
   regenerate:
-    # ubuntu-24.04 packages the pinned versions (flex 2.6.4, bison 3.8.2), so
-    # the generators run natively here; pgen.sh checks the versions before it
-    # runs them, and locally it runs the same thing in a container of the same
-    # release
+    # the exact package builds pgen.sh pins come from Ubuntu 24.04's archive, so
+    # on that runner the generators run natively; the versions installed here
+    # are the same strings pgen.sh names, so the two cannot drift apart without
+    # a change to both, and pgen.sh checks what it got before it runs
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install the pinned generators
         run: |
+          # read the package pins from the script rather than restating them
+          eval "$(grep -E '^PGEN_(FLEX|BISON)_PACKAGE=' lib/hobbes/read/pgen/pgen.sh)"
+          echo "installing $PGEN_BISON_PACKAGE $PGEN_FLEX_PACKAGE"
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends bison flex
+          sudo apt-get install -y --no-install-recommends --allow-downgrades "$PGEN_BISON_PACKAGE" "$PGEN_FLEX_PACKAGE"
           bison --version | head -1
           flex --version
       - name: Regenerate

--- a/lib/hobbes/read/pgen/pgen.sh
+++ b/lib/hobbes/read/pgen/pgen.sh
@@ -1,13 +1,86 @@
 #!/usr/bin/env bash
+# Regenerate the parser and lexer from hexpr.y and hexpr.l.
+#
+# The generated files are checked in, and the generators they were made with
+# are pinned: GNU Bison 3.8.2 and flex 2.6.4, as packaged by Ubuntu 24.04.
+# Regenerating with anything else produces a large diff of unrelated churn --
+# a different flex build of the same version number changes several hundred
+# lines -- which buries the real change and cannot be reviewed. So by default
+# this script runs the generators in a container pinned to that image, with
+# podman or docker, whichever is installed. CI regenerates the same way and
+# fails if the checked-in files differ from what the pinned generators
+# produce, so a change to hexpr.y or hexpr.l has to come with its regenerated
+# output, made by this script.
+#
+#   lib/hobbes/read/pgen/pgen.sh            # regenerate in the pinned container
+#   PGEN_NATIVE=1 lib/hobbes/read/pgen/pgen.sh  # use bison/flex from $PATH (CI, or
+#                                               # a machine with exactly these versions)
+set -euo pipefail
 
-cd `dirname ${BASH_SOURCE[0]}`
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# generate the LALR(1) parser and token definitions
-${BISON:-bison} -d -ohexpr.parse.C hexpr.y
-sed -i 's,#include "hexpr.parse.H",//&,' hexpr.parse.C
+# Ubuntu 24.04 (noble) as of the digest below ships flex 2.6.4-8.2build1 and
+# bison 2:3.8.2+dfsg-1build2. The digest pins the image; the versions are
+# asserted after install, so a moved image or repository cannot silently
+# change what generates these files.
+PGEN_IMAGE="docker.io/library/ubuntu:24.04@sha256:7607b6f97024ef850f1bd6e91a89273beb5973d04432c5b87f15f813d64b9c05"
+PGEN_FLEX_VERSION="2.6.4"
+PGEN_BISON_VERSION="3.8.2"
 
-# obey internal convention for division of source and header files
-mv hexpr.parse.H ../../../../include/hobbes/read/pgen/
+generate() {
+  # the whole version line, not just the number: Apple's flex reports itself
+  # as "flex 2.6.4 Apple(flex-35)" and generates several hundred lines
+  # differently from GNU flex 2.6.4
+  local have_flex have_bison
+  have_flex="$(flex --version 2>/dev/null | head -1 || true)"
+  have_bison="$(bison --version 2>/dev/null | head -1 || true)"
+  if [ "$have_flex" != "flex $PGEN_FLEX_VERSION" ] || [ "$have_bison" != "bison (GNU Bison) $PGEN_BISON_VERSION" ]; then
+    echo "pgen.sh: need GNU flex $PGEN_FLEX_VERSION and GNU Bison $PGEN_BISON_VERSION on \$PATH" >&2
+    echo "pgen.sh: have '${have_flex:-no flex}' and '${have_bison:-no bison}'" >&2
+    echo "pgen.sh: run without PGEN_NATIVE to use the pinned container instead" >&2
+    exit 1
+  fi
 
-# generate the lexer to tokenize string input
-${LEX:-flex} -ohexpr.lex.C hexpr.l
+  # generate the LALR(1) parser and token definitions
+  bison -d -ohexpr.parse.C hexpr.y
+  sed -i 's,#include "hexpr.parse.H",//&,' hexpr.parse.C
+
+  # bison's generated cleanup frees the parser stack only if it was moved off
+  # the initial array, but GCC cannot see that and warns (-Wfree-nonheap-object,
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753) -- which -Werror turns
+  # into a failed build. Spell the condition out where GCC can see it. This is
+  # the one hand edit the checked-in parser carries.
+  sed -i 's|^    YYSTACK_FREE (yyss);$|    YYSTACK_FREE (yyss == yyssa ? nullptr : yyss);|' hexpr.parse.C
+  sed -i 's|^#ifndef yyoverflow$|#ifndef yyoverflow\n // false positive https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753|' hexpr.parse.C
+
+  # obey internal convention for division of source and header files
+  mv hexpr.parse.H ../../../../include/hobbes/read/pgen/
+
+  # generate the lexer to tokenize string input
+  flex -ohexpr.lex.C hexpr.l
+}
+
+if [ -n "${PGEN_NATIVE:-}" ]; then
+  generate
+  exit 0
+fi
+
+if command -v podman >/dev/null 2>&1; then
+  RUNTIME=podman
+elif command -v docker >/dev/null 2>&1; then
+  RUNTIME=docker
+else
+  echo "pgen.sh: neither podman nor docker found; install one, or set PGEN_NATIVE=1 with flex $PGEN_FLEX_VERSION and bison $PGEN_BISON_VERSION on \$PATH" >&2
+  exit 1
+fi
+
+# the repository root is mounted so the header can land in include/
+ROOT="$(cd ../../../.. && pwd)"
+exec "$RUNTIME" run --rm \
+  -v "$ROOT:/hobbes:Z" -w /hobbes/lib/hobbes/read/pgen \
+  -e PGEN_NATIVE=1 \
+  "$PGEN_IMAGE" \
+  bash -c 'export DEBIAN_FRONTEND=noninteractive
+           apt-get update -qq >/dev/null
+           apt-get install -y -qq --no-install-recommends bison flex >/dev/null
+           exec ./pgen.sh'

--- a/lib/hobbes/read/pgen/pgen.sh
+++ b/lib/hobbes/read/pgen/pgen.sh
@@ -19,11 +19,17 @@ set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# Ubuntu 24.04 (noble) as of the digest below ships flex 2.6.4-8.2build1 and
-# bison 2:3.8.2+dfsg-1build2. The digest pins the image; the versions are
-# asserted after install, so a moved image or repository cannot silently
-# change what generates these files.
+# Ubuntu 24.04 (noble), pinned by digest, and the exact package builds of flex
+# and bison from its archive, pinned by version. The image digest alone would
+# not do: apt-get reads the release's repositories, which move, and a new
+# build of the same upstream version can generate differently (that is how
+# the checked-in lexer came to differ by hundreds of lines from one flex
+# 2.6.4 to another). If either package version ever leaves the archive the
+# install fails here, loudly, and the pin has to be moved on purpose --
+# with the generated files regenerated alongside it.
 PGEN_IMAGE="docker.io/library/ubuntu:24.04@sha256:7607b6f97024ef850f1bd6e91a89273beb5973d04432c5b87f15f813d64b9c05"
+PGEN_FLEX_PACKAGE="flex=2.6.4-8.2build1"
+PGEN_BISON_PACKAGE="bison=2:3.8.2+dfsg-1build2"
 PGEN_FLEX_VERSION="2.6.4"
 PGEN_BISON_VERSION="3.8.2"
 
@@ -78,9 +84,9 @@ fi
 ROOT="$(cd ../../../.. && pwd)"
 exec "$RUNTIME" run --rm \
   -v "$ROOT:/hobbes:Z" -w /hobbes/lib/hobbes/read/pgen \
-  -e PGEN_NATIVE=1 \
+  -e PGEN_NATIVE=1 -e PGEN_FLEX_PACKAGE="$PGEN_FLEX_PACKAGE" -e PGEN_BISON_PACKAGE="$PGEN_BISON_PACKAGE" \
   "$PGEN_IMAGE" \
   bash -c 'export DEBIAN_FRONTEND=noninteractive
            apt-get update -qq >/dev/null
-           apt-get install -y -qq --no-install-recommends bison flex >/dev/null
+           apt-get install -y -qq --no-install-recommends "$PGEN_BISON_PACKAGE" "$PGEN_FLEX_PACKAGE" >/dev/null
            exec ./pgen.sh'


### PR DESCRIPTION
Pins the bison and flex that generate the checked-in parser and lexer, and adds a CI check that the checked-in files are what those generators produce.

**Stacked on #548** — the pinned flex produces #548's regenerated lexer, not the one before it, so this shows #548's commits until it merges; the change here is the last commit.

### Why

`hexpr.parse.C`, `hexpr.parse.H` and `hexpr.lex.C` are checked in, generated by `pgen.sh` with whatever `bison` and `flex` are on the path, and nothing recorded which. It matters: regenerating the **unmodified** `hexpr.l` gave 997 lines of churn with Apple's flex and 809 with one GNU flex 2.6.4 build against a file from another — which is how #548 came to carry a thousand-line diff for a two-line lexer change. A generated file nobody can regenerate identically is one nobody can safely change.

### What

- **`pgen.sh`** runs the generators in a container — Ubuntu 24.04 pinned by digest, which packages GNU Bison 3.8.2 and flex 2.6.4, the versions named in the checked-in files — via podman or docker, whichever is installed. `PGEN_NATIVE=1` runs them from the path instead (CI, or a machine with exactly those versions) and refuses anything else by whole version line, since Apple's flex also calls itself 2.6.4:
  ```
  pgen.sh: need GNU flex 2.6.4 and GNU Bison 3.8.2 on $PATH
  pgen.sh: have 'flex 2.6.4 Apple(flex-35)' and 'bison (GNU Bison) 2.3'
  pgen.sh: run without PGEN_NATIVE to use the pinned container instead
  ```
- **It re-applies the one hand edit** the checked-in parser carries: bison's generated cleanup trips GCC's `-Wfree-nonheap-object` false positive (gcc bugzilla 98753), which `-Werror` turns into a failed build, so someone once spelled the condition out by hand in `hexpr.parse.C`. Regenerating dropped it; `pgen.sh` now puts it back, so it survives regeneration and is documented where it's made.
- **`.github/workflows/pgen.yml`** regenerates on every change under `lib/hobbes/read/pgen` or `include/hobbes/read/pgen` (ubuntu-24.04 packages the pinned versions, so natively) and fails on any diff. A grammar change has to come with its regenerated output, and that output has to be the pinned generators'.

### Verification

With the pin, regenerating all three files from the unmodified grammar and lexer reproduces the checked-in files **byte for byte** — `git status` shows only `pgen.sh` itself changed. Run locally through the container path and confirmed twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rGT4C394qeh2DBQhqy3Tb
