### PR TITLE
Make fuzz-parse-expr's leak-detection policy binding via default suppressions

### DIFF
--- a/fuzz/fuzz_parse_expr.C
+++ b/fuzz/fuzz_parse_expr.C
@@ -40,19 +40,32 @@
 #include <memory>
 #include <string>
 
-// Leak detection is off for this target as a matter of policy, not oversight:
-// parsing allocates from arenas that are not reclaimed per iteration, the
-// compiler's bootstrap parse strands a few grammar allocations, and LLVM
-// leaves a little of its own -- all documented in fuzz/README.md, and encoded
-// as detect_leaks=0 in the .options file this target ships with. ClusterFuzz's
-// progression task replays old testcases without honoring that file, so an
-// at-exit leak report can pin a long-fixed crash at "still reproduces"
-// (OSS-Fuzz 549863810 sat that way: the stack overflow it reports was fixed,
-// and the "crash" its progression kept seeing was LeakSanitizer complaining
-// about the bootstrap allocations after a clean run). LSan consults this hook
-// before its at-exit check, so defining it makes the policy binding wherever
-// the binary runs, whatever environment it is run with.
-extern "C" int __lsan_is_turned_off() { return 1; }
+// Hobbes reclaims evaluation memory by resetting an arena at the end of a
+// transaction, not by releasing objects one at a time -- so a per-allocation
+// leak audit reports transaction-scoped data as lost by design. For this
+// target that means two families of expected reports: allocations made by
+// grammar actions during a parse (yyparse and the paths into it), which the
+// compiler's bootstrap parse strands once per cc, and a little that LLVM
+// keeps for itself. The .options file ships detect_leaks=0 for exactly this
+// reason, but ClusterFuzz's progression task replays old testcases without
+// honoring that file, and an at-exit leak report then pins a long-fixed
+// crash at "still reproduces" (OSS-Fuzz 549863810 sat that way: its stack
+// overflow was fixed, and the "crash" progression kept seeing was
+// LeakSanitizer complaining about bootstrap allocations after a clean run).
+//
+// LSan reads default suppressions from this hook, so naming the expected
+// stacks here makes the policy travel inside the binary, whatever
+// environment it is run with -- while leaving leak detection itself alive:
+// an allocation leaked from anywhere else (the harness, the compiler's own
+// bookkeeping, a future regression that strands genuinely owned memory)
+// still fails the run. This is deliberately narrower than turning the
+// checker off.
+extern "C" const char* __lsan_default_suppressions() {
+  return
+    "leak:yyparse\n"                    // grammar-action allocations, arena-scoped by design
+    "leak:hobbes::runParserOnBuffer\n"  // the same parse, when yyparse is inlined out of the stack
+    "leak:llvm::\n";                    // LLVM's own retained allocations are not ours to free
+}
 
 namespace {
 

--- a/fuzz/fuzz_parse_expr.C
+++ b/fuzz/fuzz_parse_expr.C
@@ -40,6 +40,20 @@
 #include <memory>
 #include <string>
 
+// Leak detection is off for this target as a matter of policy, not oversight:
+// parsing allocates from arenas that are not reclaimed per iteration, the
+// compiler's bootstrap parse strands a few grammar allocations, and LLVM
+// leaves a little of its own -- all documented in fuzz/README.md, and encoded
+// as detect_leaks=0 in the .options file this target ships with. ClusterFuzz's
+// progression task replays old testcases without honoring that file, so an
+// at-exit leak report can pin a long-fixed crash at "still reproduces"
+// (OSS-Fuzz 549863810 sat that way: the stack overflow it reports was fixed,
+// and the "crash" its progression kept seeing was LeakSanitizer complaining
+// about the bootstrap allocations after a clean run). LSan consults this hook
+// before its at-exit check, so defining it makes the policy binding wherever
+// the binary runs, whatever environment it is run with.
+extern "C" int __lsan_is_turned_off() { return 1; }
+
 namespace {
 
 const unsigned long inputsPerCompaction = 64;


### PR DESCRIPTION
OSS-Fuzz 549863810 (stack-overflow in `seqR`/`diffRegex`) was fixed by #543, and ClusterFuzz's own lifecycle recorded it fixed in the `202608210625:202608220635` revision range — but the testcase flipped back to "still crashes" on Aug 27 and 28, and the tracker holds it at **Fixed: NO**. The progression log shows what it is actually seeing: the testcase executes cleanly 100 times, and then **LeakSanitizer fires at exit** over allocations that have nothing to do with the input — grammar-action allocations stranded by the compiler's bootstrap parse, one 22-byte `llvm::Value::setNameImpl` allocation, and strings reachable only from those. Progression counts any sanitizer report as a crash, so an at-exit leak pins a fixed stack overflow open indefinitely.

These reports are expected under hobbes' memory model, not defects: evaluation memory is transaction-scoped, reclaimed by resetting an arena rather than by destructors (see #560), so a per-allocation audit reports transaction-scoped data as lost by design. The `.options` file already ships `detect_leaks=0` for this reason — but the progression task replays old testcases without honoring it, so the policy has to travel inside the binary.

**Approach (reworked from the first commit after review):** rather than `__lsan_is_turned_off()`, which silences the checker entirely, the harness defines `__lsan_default_suppressions()` naming the expected stacks — `yyparse` and `hobbes::runParserOnBuffer` (parse allocations, arena-scoped by design) and `llvm::` (LLVM's own retained allocations). This travels inside the binary just the same, but leaves leak detection **alive** for everything else: a future regression that strands genuinely owned memory still fails the run.

Verified in a Linux ASan container (Ubuntu 24.04 / clang-18), replaying the 549863810 reproducer with `ASAN_OPTIONS=detect_leaks=1` forced on:

* **With the suppressions**: exit 0, LSan prints "Suppressions used:" — the exact failure progression records becomes a clean exit. (Without any of this, the parent commit exits 1 with the byte-identical leak report ClusterFuzz's published binary produces: `1248 bytes in 52 objects` direct, `23,124 bytes in 422 allocations` total.)
* **With a 1KB leak deliberately planted in `LLVMFuzzerTestOneInput`**: the run still fails (exit 77) reporting precisely that allocation — coverage the blanket switch could not offer.

Also verified: the harness builds and replays the reproducer cleanly on macOS, and the full hobbes-test suite and all 133 rosetta examples pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Cf5Cv9r1wqa2YcgCWoLC3