### PR TITLE
fix(events): respect timeoutMS parameter in stepEventLoop when timers are active

### DIFF
--- a/lib/hobbes/events/events.C
+++ b/lib/hobbes/events/events.C
@@ -93,16 +93,23 @@ void registerInterruptHandler(const std::function<void()>& fn) {
 
 bool stepEventLoop(int timeoutMS, const std::function<bool()>& stopFn) {
   while (!stopFn()) {
+    int effectiveTimeoutMS = timeoutMS;
+
     if (!timers.empty()) {
       auto next = timers.top().callTime;
       auto timeUntilNext = next - std::chrono::high_resolution_clock::now();
       int millis = std::chrono::duration_cast<std::chrono::milliseconds>(timeUntilNext).count();
-      timeoutMS = std::max(1, millis);
+      int timerTimeout = std::max(1, millis);
+      if (timeoutMS >= 0) {
+        effectiveTimeoutMS = std::min(timeoutMS, timerTimeout);
+      } else {
+        effectiveTimeoutMS = timerTimeout;
+      }
+    } else if (timeoutMS < 0) {
+      // When stopFn is provided with no explicit timeout, poll every 500ms
+      // so the stop condition gets checked instead of blocking indefinitely.
+      effectiveTimeoutMS = 500;
     }
-
-    // When stopFn is provided with no explicit timeout, poll every 500ms
-    // so the stop condition gets checked instead of blocking indefinitely.
-    int effectiveTimeoutMS = timeoutMS < 0 ? 500 : timeoutMS;
 
     struct epoll_event evts[64];
     int fds = epoll_wait(threadEPollFD(), evts, sizeof(evts)/sizeof(evts[0]), effectiveTimeoutMS);


### PR DESCRIPTION
## Problem
In `stepEventLoop(timeoutMS, stopFn)`, if `timers` was non-empty, `timeoutMS` was unconditionally overwritten with the time until the next scheduled timer (`timeoutMS = std::max(1, millis)`). If a caller explicitly passed a custom `timeoutMS` (e.g. 50ms) while a timer was scheduled 5 seconds in the future, the loop ignored the caller's timeout parameter and blocked for the full 5 seconds.

## Solution
Updated `stepEventLoop` to set `effectiveTimeoutMS = std::min(timeoutMS, timerTimeout)` whenever `timeoutMS >= 0`, ensuring neither the caller's timeout nor scheduled timers are starved.

Fixes #436