### PR TITLE
Give hi a syntax-check mode: -n / --check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.sw?
 /build/
+/build-*/
 __pycache__/
 *.py[cod]
 CMakeCache.txt
@@ -14,11 +15,16 @@ CMakeFiles/
 CTestTestfile.cmake
 Makefile
 cmake_install.cmake
-hi
-hobbes-test
-hog
-libhobbes-pic.a
-libhobbes.a
-macos_setup.sh
-mock-proc
+
+# binaries and libraries an in-tree build drops at the repository root.
+# anchored to the root: the bare names used to shadow real source paths
+# (the pattern 'hi' ignored the bin/hi/ source directory, 'hog' bin/hog/),
+# so a new file added under those directories was silently ignored.
+/hi
+/hobbes-test
+/hog
+/libhobbes-pic.a
+/libhobbes.a
+/macos_setup.sh
+/mock-proc
 test_report.json

--- a/bin/hi/evaluator.H
+++ b/bin/hi/evaluator.H
@@ -21,11 +21,12 @@ struct Args {
   int                      replPort;
   int                      httpdPort;
   bool                     exitAfterEval;
+  bool                     checkOnly;      // just verify that script files parse; compile and evaluate nothing
   NameVals                 scriptNameVals;
   bool                     machineREPL;    // should we structure console I/O for machine-reading?
   strs                     opts;
 
-  Args() : useDefColors(false), silent(false), replPort(-1), httpdPort(-1), exitAfterEval(false), machineREPL(false) {
+  Args() : useDefColors(false), silent(false), replPort(-1), httpdPort(-1), exitAfterEval(false), checkOnly(false), machineREPL(false) {
     opts.push_back("Safe");
   }
 };

--- a/bin/hi/main.C
+++ b/bin/hi/main.C
@@ -592,6 +592,7 @@ void printUsage() {
             << "    -e          : evaluate <expr>"                                                          << std::endl
             << "    -s          : run in 'silent' mode without normal formatting"                           << std::endl
             << "    -x          : exit after input scripts are evaluated"                                   << std::endl
+            << "    -n          : just check that input scripts parse; compile and evaluate nothing"        << std::endl
             << "    -o opt      : enable language option 'opt'"                                             << std::endl
             << "    -a name=val : add a name/val pair to the set of arguments passed to subsequent scripts" << std::endl
             << "    files       : hobbes script files to evaluate"                                          << std::endl
@@ -625,6 +626,8 @@ Args processCommandLine(int argc, char** argv) {
       r.silent = true;
     } else if (arg == "-x" || arg == "--exitAfterEval") {
       r.exitAfterEval = true;
+    } else if (arg == "-n" || arg == "--check") {
+      r.checkOnly = true;
     } else if (arg == "-z") {
       r.machineREPL = true;
       r.silent = true;
@@ -684,6 +687,34 @@ int main(int argc, char** argv) {
   try {
     // read command-line arguments
     Args args = processCommandLine(argc, argv);
+
+    // just verify that the named scripts parse, in the spirit of 'python -m
+    // py_compile' or 'ruby -c'. A script is typically loaded after other
+    // files and definitions it depends on, so syntax is all that can be
+    // checked about it in isolation -- nothing is compiled or evaluated,
+    // imports are not resolved, and ~/.hirc is not loaded. Errors go to
+    // stderr with their locations; the exit status says whether every file
+    // parsed.
+    if (args.checkOnly) {
+      if (args.mfiles.empty()) {
+        std::cerr << "hi: -n/--check requires at least one script file" << std::endl;
+        return 1;
+      }
+      hobbes::cc c;
+      int badFiles = 0;
+      for (const auto& mfile : args.mfiles) {
+        try {
+          c.readModuleFile(str::expandPath(mfile));
+          if (!args.silent) {
+            std::cout << mfile << ": syntax OK" << std::endl;
+          }
+        } catch (std::exception& ex) {
+          std::cerr << ex.what() << std::endl;
+          ++badFiles;
+        }
+      }
+      return badFiles == 0 ? 0 : 1;
+    }
 
     // start an evaluator and process ~/.hirc if it exists
     // (this should apply whatever settings the user prefers)

--- a/doc/en/appendix/hi.rst
+++ b/doc/en/appendix/hi.rst
@@ -103,3 +103,30 @@ Commandline options
 
 -p nnnn
   Listen on port *nnnn*
+
+-n, --check
+  Syntax-check mode: verify that the named script files parse, and do nothing
+  else. In the spirit of ``python -m py_compile`` or ``ruby -c``: a script is
+  typically loaded after other files and definitions it depends on, so its
+  syntax is all that can be validated in isolation — nothing is compiled or
+  evaluated, imports are not resolved, unresolved names are not an error, and
+  ``~/.hirc`` is not loaded. Each file that parses is reported with
+  ``syntax OK`` (suppressed under ``-s``); each that does not gets its parse
+  error, with location, on stderr. The exit status is 0 when every file
+  parsed and 1 otherwise, so it slots directly into CI or an editor hook:
+
+  ::
+
+    $ hi -n broken.hob
+    broken.hob:3,16-16: syntax error, unexpected end of file
+    $ echo $?
+    1
+
+-x, --exitAfterEval
+  Exit after evaluating the input scripts instead of starting the REPL
+
+-e expr
+  Evaluate the expression *expr*
+
+-o opt
+  Enable language option *opt*


### PR DESCRIPTION
There was no way to ask whether a `.hob` file parses without also running it: `hi`'s only file mode loads a script into the JIT, which compiles and evaluates it — the wrong tool for validation, since a script is typically loaded after other files and definitions it depends on, and cannot compile (let alone run) in isolation. Its syntax is the one property it has on its own, and checking that meant writing a bespoke driver against `cc::readModuleFile`.

`hi -n` (long form `--check`) does exactly and only that, in the spirit of `python -m py_compile` or `ruby -c`: each named file is read through `cc::readModuleFile`, which parses and builds the module AST without compiling or evaluating anything — imports are not resolved, unresolved names are not an error, and `~/.hirc` is not loaded (the check runs before the evaluator would be constructed, so the REPL machinery never starts). Files that parse report `syntax OK` (suppressed under `-s`); files that do not get their parse error, with file, line and column, on stderr. The exit status is 0 when every file parsed and 1 otherwise, so the flag drops into CI and editor hooks directly:

```
$ hi -n broken.hob
broken.hob:3,16-16: syntax error, unexpected end of file
$ echo $?
1
```

Checked against: a well-formed file, a file full of names defined nowhere (passes — parse only), a truncated file (reported with location, exit 1), a mixed list (every file checked, exit reflects the failures), and all 133 rosetta example scripts in one invocation. The appendix documentation for `hi` gains the flag — alongside entries for `-x`, `-e`, and `-o`, which the options list had never caught up with — and renders cleanly under Sphinx. Full hobbes-test suite and all 133 rosetta examples pass.

---

**Also included** (a second commit, found while adding the flag): `.gitignore` anchoring. The bare `hi` and `hog` patterns for root-level build binaries also matched the `bin/hi/` and `bin/hog/` source directories, so `git add` on new files there required `-f` and untracked files were invisible to `git status`. The artifact names are now anchored to the root (`/hi`, `/hog`, `/hobbes-test`, ...), `/build-*/` joins `/build/` per the fuzz docs' dedicated-build-dir recommendation, and `Makefile` deliberately stays unanchored since in-tree cmake scatters Makefiles everywhere (the tracked Sphinx `doc/en/Makefile` is shadowed but unaffected). Verified with `git check-ignore` on every renamed pattern and a sweep of all tracked files against the rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Cf5Cv9r1wqa2YcgCWoLC3
