### PR TITLE
Anchor build-artifact names in .gitignore to the repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.sw?
 /build/
+/build-*/
 __pycache__/
 *.py[cod]
 CMakeCache.txt
@@ -14,11 +15,16 @@ CMakeFiles/
 CTestTestfile.cmake
 Makefile
 cmake_install.cmake
-hi
-hobbes-test
-hog
-libhobbes-pic.a
-libhobbes.a
-macos_setup.sh
-mock-proc
+
+# binaries and libraries an in-tree build drops at the repository root.
+# anchored to the root: the bare names used to shadow real source paths
+# (the pattern 'hi' ignored the bin/hi/ source directory, 'hog' bin/hog/),
+# so a new file added under those directories was silently ignored.
+/hi
+/hobbes-test
+/hog
+/libhobbes-pic.a
+/libhobbes.a
+/macos_setup.sh
+/mock-proc
 test_report.json


### PR DESCRIPTION
The names of the binaries an in-tree build drops at the repository root were listed bare in `.gitignore`, and a bare pattern matches that name anywhere in the tree: `hi` ignored the `bin/hi/` **source directory** and `hog` ignored `bin/hog/`, so adding a new file under either required `git add -f`, and an untracked file there was silently invisible to `git status` (found while adding the `-n`/`--check` flag in #563). Anchoring the artifact names to the root keeps them ignored where they are produced and nowhere else.

Also ignores `/build-*/` alongside `/build/`, since the fuzzing docs recommend a dedicated build directory (`build-fuzz`) rather than sharing one with normal development builds.

`Makefile` stays unanchored deliberately: an in-tree cmake run scatters generated Makefiles into every subdirectory. The tracked `doc/en/Makefile` (Sphinx) is shadowed by that pattern, but a tracked file is unaffected by ignore rules beyond a warning on explicit re-add.

Verified: `bin/hi/` and `bin/hog/` are no longer ignored, each anchored artifact still is (`git check-ignore` on every name), and `git ls-files | git check-ignore --stdin --no-index` shows no tracked file besides the known `doc/en/Makefile` matching any rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Cf5Cv9r1wqa2YcgCWoLC3