### PR TITLE
Replay the fuzz corpora as tests, under the sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,11 +162,14 @@ target_link_libraries(hi PUBLIC "-rdynamic" PRIVATE hobbes ${Readline_LIBRARIES}
 add_executable(hog ${hog_files})
 target_link_libraries(hog PRIVATE hobbes)
 
+# before add_subdirectory(fuzz): the corpus replay tests it registers only
+# take effect in a directory where testing is already enabled
+enable_testing()
+
 if(BUILD_FUZZERS)
   add_subdirectory(fuzz)
 endif()
 
-enable_testing()
 add_executable(mock-proc test/mocks/proc.C)
 add_executable(hobbes-test ${test_files})
 target_link_libraries(hobbes-test PRIVATE hobbes)

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -23,13 +23,18 @@ set(FUZZING_ENGINE_LIB "" CACHE STRING
 # wants the corpus replayed -- the standalone runner replays it just as well.
 include(CheckCXXSourceCompiles)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  set(CMAKE_REQUIRED_FLAGS "-fsanitize=fuzzer")
+  # append rather than replace, and put back whatever was there: a toolchain
+  # file may have set flags the probe needs to compile at all (a sysroot, a
+  # stdlib), and the rest of the configuration needs them after it
+  set(saved_required_flags "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fsanitize=fuzzer")
   check_cxx_source_compiles("
     #include <cstddef>
     #include <cstdint>
     extern \"C\" int LLVMFuzzerTestOneInput(const uint8_t*, size_t) { return 0; }
   " HAVE_LIBFUZZER)
-  unset(CMAKE_REQUIRED_FLAGS)
+  set(CMAKE_REQUIRED_FLAGS "${saved_required_flags}")
+  unset(saved_required_flags)
 endif()
 
 if(FUZZING_ENGINE_LIB)

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -16,11 +16,27 @@
 set(FUZZING_ENGINE_LIB "" CACHE STRING
     "Fuzzing engine to link harnesses against (e.g. OSS-Fuzz's LIB_FUZZING_ENGINE); libFuzzer via -fsanitize=fuzzer when empty")
 
+# Clang is the usual source of libFuzzer, but having Clang is not the same as
+# having it: a distribution can package the sanitizer runtimes separately, and
+# then -fsanitize=fuzzer compiles and fails to link. Ask the toolchain instead
+# of assuming, so that turning BUILD_FUZZERS on cannot break a build that only
+# wants the corpus replayed -- the standalone runner replays it just as well.
+include(CheckCXXSourceCompiles)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  set(CMAKE_REQUIRED_FLAGS "-fsanitize=fuzzer")
+  check_cxx_source_compiles("
+    #include <cstddef>
+    #include <cstdint>
+    extern \"C\" int LLVMFuzzerTestOneInput(const uint8_t*, size_t) { return 0; }
+  " HAVE_LIBFUZZER)
+  unset(CMAKE_REQUIRED_FLAGS)
+endif()
+
 if(FUZZING_ENGINE_LIB)
   set(fuzz_driver "")
   set(fuzz_flags "")
   message(STATUS "fuzzers: linking against externally supplied engine ${FUZZING_ENGINE_LIB}")
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+elseif(HAVE_LIBFUZZER)
   set(fuzz_driver "")
   set(fuzz_flags -fsanitize=fuzzer)
   message(STATUS "fuzzers: building with libFuzzer (${CMAKE_CXX_COMPILER_ID})")
@@ -47,3 +63,40 @@ endfunction()
 add_fuzzer(fuzz-type-decode fuzz_type_decode.C)
 add_fuzzer(fuzz-fregion-reader fuzz_fregion_reader.C)
 add_fuzzer(fuzz-parse-expr fuzz_parse_expr.C)
+
+# Replay each harness's checked-in corpus as part of `ctest`.
+#
+# The corpus is where reproducers land when a fuzzing service reports a crash,
+# and until now nothing in a normal build ran them: the harnesses are only
+# built when BUILD_FUZZERS is on, and the seeds reached a fuzzer only through
+# the zips oss-fuzz-build.sh hands to OSS-Fuzz and ClusterFuzzLite. Replaying
+# them here costs seconds -- the whole parse-expr corpus is about fifteen --
+# and turns them into a regression test that runs under whatever sanitizers
+# the build was configured with, on every compiler in the matrix.
+function(add_corpus_replay_test harness corpus)
+  set(dir "${CMAKE_CURRENT_SOURCE_DIR}/corpus/${corpus}")
+  if(NOT IS_DIRECTORY "${dir}")
+    return()
+  endif()
+
+  add_test(
+    NAME ${harness}-corpus
+    COMMAND ${CMAKE_COMMAND}
+            -DHARNESS=$<TARGET_FILE:${harness}>
+            -DCORPUS=${dir}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/replay-corpus.cmake)
+
+  # Hobbes reclaims evaluation memory by resetting an arena rather than
+  # freeing objects one at a time, so a leak check at exit reports
+  # transaction-scoped data as lost by design -- which is why the .options
+  # files shipped to OSS-Fuzz carry detect_leaks=0. ctest does not read those,
+  # so say it here. LSAN_OPTIONS rather than ASAN_OPTIONS: it is read second
+  # for leak settings, and so does not discard the rest of a build's ASan
+  # configuration.
+  set_tests_properties(${harness}-corpus PROPERTIES
+    ENVIRONMENT "LSAN_OPTIONS=detect_leaks=0")
+endfunction()
+
+add_corpus_replay_test(fuzz-type-decode type-decode)
+add_corpus_replay_test(fuzz-fregion-reader fregion-reader)
+add_corpus_replay_test(fuzz-parse-expr parse-expr)

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -18,9 +18,12 @@ these should run under sanitizers.
 ## Building
 
 Requires a Clang that ships libFuzzer (upstream or Homebrew Clang; Apple's
-Xcode Clang does not). With any other compiler the same targets build as
-standalone runners that replay input files named on the command line, which
-is also the convenient way to check a crash reproducer.
+Xcode Clang does not). Whether a Clang has it is decided by trying to link
+against it rather than by assuming, since a distribution can package the
+sanitizer runtimes apart from the compiler. With any other compiler -- or a
+Clang without libFuzzer -- the same targets build as standalone runners that
+replay input files named on the command line, which is also the convenient
+way to check a crash reproducer.
 
 With Clang, `BUILD_FUZZERS=ON` compiles the whole build (including
 `libhobbes`) with `-fsanitize=fuzzer-no-link` so the fuzzers observe coverage
@@ -31,6 +34,28 @@ for fuzzing rather than sharing one with normal development builds.
 cmake -B build-fuzz -DCMAKE_BUILD_TYPE=Debug -DBUILD_FUZZERS=ON -DUSE_ASAN_AND_UBSAN=ON
 cmake --build build-fuzz -j --target fuzz-type-decode fuzz-fregion-reader fuzz-parse-expr
 ```
+
+## Replaying the corpus
+
+`BUILD_FUZZERS=ON` also registers a ctest test per harness that replays every
+input in its `corpus/` directory once:
+
+```bash
+ctest --test-dir build-fuzz -R corpus
+```
+
+This needs no fuzzing engine and says nothing about coverage -- it is a
+regression check. Each of those inputs is a reproducer for something that
+once crashed hobbes, so replaying them under whatever sanitizers the build
+enables is worth the seconds it costs (the parse-expr corpus, the largest, is
+about fifteen). The corpus is read when the test runs rather than when cmake
+configured, so a reproducer committed alongside a fix is picked up by the next
+`ctest` with nothing to reconfigure.
+
+CI runs this in the `clang-*-ASanAndUBSan` builds, which are the ones with
+both sanitizers on. It is distinct from the ClusterFuzzLite job, which hands
+the same corpus to a real fuzzer for a few minutes on pull requests that touch
+covered code.
 
 ## Running
 

--- a/fuzz/replay-corpus.cmake
+++ b/fuzz/replay-corpus.cmake
@@ -1,0 +1,43 @@
+# Replay every input in a corpus directory through a fuzz harness, once each.
+#
+# Driven as a ctest command rather than expanded into add_test() so that the
+# corpus is read when the test runs and not when cmake last configured it: a
+# reproducer committed alongside a fix is then replayed by the next `ctest`,
+# with nothing to remember to reconfigure.
+#
+# Both shapes of harness take inputs as arguments and fail by exiting non-zero
+# -- libFuzzer runs each named file once, and the standalone runner built for
+# compilers without libFuzzer does the same -- so this needs no fuzzing engine
+# and says nothing about coverage. It is a regression check: every input that
+# once crashed hobbes, replayed under whatever sanitizers the build enables.
+#
+# Expects HARNESS (the built executable) and CORPUS (a directory of inputs).
+
+if(NOT DEFINED HARNESS OR NOT DEFINED CORPUS)
+  message(FATAL_ERROR "replay-corpus: both HARNESS and CORPUS must be defined")
+endif()
+
+file(GLOB entries "${CORPUS}/*")
+
+set(inputs "")
+foreach(entry IN LISTS entries)
+  if(NOT IS_DIRECTORY "${entry}")
+    list(APPEND inputs "${entry}")
+  endif()
+endforeach()
+
+if(NOT inputs)
+  message(STATUS "replay-corpus: no inputs in ${CORPUS}, nothing to replay")
+  return()
+endif()
+
+list(LENGTH inputs count)
+message(STATUS "replay-corpus: replaying ${count} input(s) from ${CORPUS}")
+
+execute_process(COMMAND "${HARNESS}" ${inputs} RESULT_VARIABLE status)
+
+# a signal is reported as a string ("Segmentation fault"), an exit code as a
+# number, and either means the harness did not survive its own corpus
+if(NOT status STREQUAL "0")
+  message(FATAL_ERROR "replay-corpus: ${HARNESS} did not survive ${CORPUS} (${status})")
+endif()

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -84,6 +84,11 @@ let
       cmakeBuildType="Debug";
       cmakeFlags = [
         "-DUSE_ASAN_AND_UBSAN:BOOL=ON"
+        # builds the fuzz harnesses so that ctest replays their corpora here.
+        # this is the one build in the matrix with both sanitizers on, which
+        # is what those inputs are worth replaying under -- every one of them
+        # is a reproducer for something that once crashed hobbes
+        "-DBUILD_FUZZERS:BOOL=ON"
       ];
       ninjaFlags = [ "-v" ];
       UBSAN_OPTIONS="print_stacktrace=1";


### PR DESCRIPTION
Follow-up to #570 and #571, which both add a reproducer to `fuzz/corpus/`. Nothing in a normal build ever ran those files.

### What was missing

`fuzz/CMakeLists.txt` registered no tests, and the only two ctest tests are `hobbes-test` and `rosetta-examples`. `BUILD_FUZZERS` defaults to `OFF` and appears nowhere in `nix/`, `flake.nix` or `.github/`, so the `ASanAndUBSan` builds — the ones with the sanitizers on — did not even compile the harnesses.

The corpus reached a fuzzer only through the seed-corpus zips `oss-fuzz-build.sh` hands to OSS-Fuzz and to the ClusterFuzzLite job. That job is worth having, but it is a 300-second `code-change` fuzzing session on ASan alone, gated on paths, and it asserts nothing about any particular input. So a reproducer committed with a fix was documentation, not a regression test.

### What this does

- Registers one ctest test per harness that replays every input in its corpus directory once. Both shapes of harness already take inputs as arguments and fail by exiting non-zero — libFuzzer runs each named file once, and the standalone runner does the same — so this needs no fuzzing engine and says nothing about coverage. It is purely a regression check.
- Turns `BUILD_FUZZERS` on in the ASanAndUBSan nix build, so the replay happens under `-fsanitize=address,undefined` across all four LLVM versions in that matrix.
- Decides whether the compiler has libFuzzer by trying to link against it rather than by inferring it from the compiler id. Having Clang is not the same as having libFuzzer — a distribution can package the sanitizer runtimes apart from the compiler, and `-fsanitize=fuzzer` then compiles and fails to link. This matters for a local `BUILD_FUZZERS=ON` build more than for CI (see below); it is cheap insurance either way, since the standalone runner replays a corpus just as well.
- Moves `enable_testing()` above `add_subdirectory(fuzz)`, since tests registered in a directory where testing is not yet enabled do not take effect.

The corpus is globbed when the test runs rather than when cmake configured, so a reproducer committed alongside a fix is replayed by the next `ctest` with nothing to reconfigure.

### What the sanitizer matrix actually is

Worth recording, because the job names suggest otherwise: `linux-clang-<N>-ASanAndUBSan` builds with **gcc** against LLVM `<N>` as a library — CMake reports `CXX_COMPILER_ID` as `GNU` there. So in these jobs:

- `-fsanitize=address,undefined` applies (it is unconditional), which is what makes replaying the corpus there worthwhile;
- the extra Clang-only UBSan checks (`local-bounds`, `nullability`, `signed-integer-overflow`, ...) do not;
- `-fsanitize=fuzzer-no-link` does not, since it is gated on Clang — so turning `BUILD_FUZZERS` on adds no coverage instrumentation to this build, and the harnesses come out as standalone runners. The replay is therefore deterministic, with no fuzzing engine in the picture.

### Cost

Seconds. In CI the parse-expr replay took 11.5s over 16 inputs and the other two 0.02s each, against an ASan job that already runs 20-35 minutes.

### Verification

- CI: all 35 checks pass. The clang-18 build log shows `fuzzers: GNU has no libFuzzer; building standalone reproducer runners`, then `100% tests passed, 0 tests failed out of 5` — so the three replay tests really did register and run, rather than passing by not existing.
- Locally with a real Clang, the probe succeeds, the harnesses build against libFuzzer, and the same three tests pass in 14.1s.
- Forcing the probe off locally: falls back to `standalone_main.C`, drops `-fsanitize=fuzzer`, and replays the whole parse-expr corpus in 8.5s.
- Failure actually propagates, which is the point of the test: a harness exiting non-zero and a harness killed by SIGSEGV both fail the ctest, and the message names the harness, the corpus and the status.
- An empty or absent corpus directory is a pass, not an error.
- With `BUILD_FUZZERS` left at its default, configure is unchanged and still registers exactly two tests.
