### PR TITLE
Release a cc's interned types when it is destroyed

### DIFF
--- a/doc/en/embedding/recompiling.rst
+++ b/doc/en/embedding/recompiling.rst
@@ -161,9 +161,11 @@ Its properties:
   one. Keeping a *spare* ``cc`` — bootstrapped with the prelude ahead of
   time and refilled after each use — hides the prelude; it does not hide
   the other tables.
-* **Destroying the old ``cc`` reclaims little.** See
-  :ref:`hobbes_recompiling_budget`; do not choose this pattern for its
-  memory behaviour.
+* **Destroying the old ``cc`` reclaims what it compiled.** A ``cc``
+  compacts the process-wide type memo as the last step of its destruction,
+  so the types its tables interned go with it (see
+  :ref:`hobbes_recompiling_budget`). This is the pattern whose memory use
+  is bounded by one generation rather than by the number of edits.
 
 Pattern two: two compilers, alternating
 =======================================
@@ -267,26 +269,33 @@ What to budget
 ==============
 
 Measured on a release build (clang 18, LLVM 18, x86-64 Linux), compiling
-five successive versions of a generated match table into one long-lived
-``cc``, resident size read after ``malloc_trim`` so it reflects what is
-retained rather than what the allocator is holding:
+successive versions of a generated match table into one long-lived ``cc``,
+resident size read after ``malloc_trim`` so it reflects what is retained
+rather than what the allocator is holding. The process is 22 MB before the
+first ``cc`` and 68 MB with a fresh, empty one:
 
-====================================  ========  ====================  ==================================
-Table                                 Compile   Retained per version  Freed when the ``cc`` is destroyed
-====================================  ========  ====================  ==================================
-70 rows × 12 columns, row-pivot       ~17 s     ~150 MB               ~20%
-70 × 12, ``buildColumnwiseMatches``   ~0.7 s    ~24 MB                ~10%
-400 × 12, ``buildColumnwiseMatches``  ~5 s      ~150 MB               ~12%
-====================================  ========  ====================  ==================================
+====================================  ========  ====================  ====================================
+Table                                 Compile   Retained per version  Resident after the ``cc`` is destroyed
+====================================  ========  ====================  ====================================
+70 rows × 12 columns, row-pivot       ~17 s     ~150 MB               ~60 MB
+70 × 12, ``buildColumnwiseMatches``   ~0.7 s    ~24 MB                ~50 MB
+400 × 12, ``buildColumnwiseMatches``  ~5 s      ~150 MB               ~60 MB
+====================================  ========  ====================  ====================================
 
 Three things follow.
 
 * **Every compile of a large table pins on the order of 100 MB for the
-  life of the process**, in either pattern. Destroying the ``cc`` returns
-  only a small fraction of it, so building a fresh ``cc`` per change is not
-  a way to avoid the growth. Multiply by the number of edits per day and by
-  the number of days between restarts, and watch resident size in
-  production rather than assuming.
+  life of the ``cc``.** Most of it is the process-wide memo of interned
+  types, which a ``cc`` compacts as the last step of its destruction; the
+  rest is the annotated expression of every definition the compile drained,
+  which the ``cc`` keeps for inlining and which goes when it does. So
+  pattern one's memory is bounded by one generation, while pattern two
+  grows by roughly the figures above per edit until a side is rebuilt.
+  Nothing on the compile path compacts the memo by itself; a process that
+  keeps one ``cc`` for a long time and wants the growth back sooner can call
+  ``hobbes::compactMTypeMemory()`` after a compile, from any thread — it
+  takes the memo's own lock, not the compiler's. Either way, watch resident
+  size in production rather than assuming.
 * **``buildColumnwiseMatches`` is the largest lever available.** For the
   same 70-row table it is a 25× faster compile and 6× less memory; a
   400-row table compiles columnwise in the time a 70-row one takes

--- a/include/hobbes/eval/cc.H
+++ b/include/hobbes/eval/cc.H
@@ -95,6 +95,13 @@ template <typename... NamesAndExpr> struct PArgl<std::string, NamesAndExpr...> {
 
 // the main compiler
 class cc : public typedb {
+private:
+  // the types a compiler interns live in a process-wide memo that only
+  // releases entries when compacted. Declared first so that it is destroyed
+  // last: by then every other member has dropped its type references, and
+  // the compaction releases whatever this compiler alone was keeping alive
+  CompactMTypeMemoryAtExit compactTypesOnDestroy;
+
 public:
   cc();
   virtual ~cc();

--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -587,11 +587,8 @@ MTypeCtorMaps* tctorMaps() {
   return x;
 }
 
-// releasing a type releases its references to the types it is made of, which
-// a single pass over the memo may already have walked past, so repeat until a
-// pass frees nothing
 void compactMTypeMemory() {
-  while (tctorMaps()->compact() > 0) { }
+  tctorMaps()->compact();
 }
 
 template <typename Class, typename T, typename ... Args>

--- a/lib/hobbes/lang/type.C
+++ b/lib/hobbes/lang/type.C
@@ -587,8 +587,11 @@ MTypeCtorMaps* tctorMaps() {
   return x;
 }
 
+// releasing a type releases its references to the types it is made of, which
+// a single pass over the memo may already have walked past, so repeat until a
+// pass frees nothing
 void compactMTypeMemory() {
-  tctorMaps()->compact();
+  while (tctorMaps()->compact() > 0) { }
 }
 
 template <typename Class, typename T, typename ... Args>

--- a/test/Compiler.C
+++ b/test/Compiler.C
@@ -188,3 +188,24 @@ TEST(Compiler, threadRegionsAreReleasedOnThreadExit) {
   EXPECT_TRUE(makeString("still here") != nullptr);
 }
 
+
+TEST(Compiler, destroyingCCReleasesItsTypes) {
+  // every type a compiler interns lands in a process-wide memo that only
+  // releases entries when compacted, and nothing on the compile path
+  // compacts it: a process that compiled a large definition kept its types
+  // for good, even after the cc that made them was gone (a 400-row match
+  // table pinned ~150MB per compile). A cc now compacts the memo as the last
+  // step of its destruction, so what it alone was keeping alive is released.
+  std::weak_ptr<MonoType> t;
+  {
+    cc lc;
+    // a type nothing else in the process will have interned
+    MonoTypePtr rt = lc.readMonoType("{ccDestroyReleasesTypesF0:int, ccDestroyReleasesTypesF1:[char], ccDestroyReleasesTypesF2:{a:double, b:[byte]}}");
+    EXPECT_TRUE(is<Record>(rt));
+    t = rt;
+    // rt is released here, before lc; a live cc does not by itself free
+    // types (they are shared with every other cc), so the entry survives
+    // until the compiler goes
+  }
+  EXPECT_TRUE(t.expired());
+}


### PR DESCRIPTION
## What

A `hobbes::cc` now compacts the process-wide type memo as the last step of its destruction, so the types its compiles interned are released with it.

## Why

Every interned type lives in `tctorMaps()` (`lib/hobbes/lang/type.C`), whose entries are only erased by `compactMTypeMemory()`. Nothing on the compile path calls it — only `findProperties` and the net/prepl request handlers — so a process that compiled a large definition kept its types for good, even after the `cc` was gone. This is what made a long-running process that recompiles logic (see `doc/en/embedding/recompiling.rst`, #575) grow by ~150MB per large match-table compile with no way back.

heaptrack on a driver compiling three versions of a 400×12 match table into one `cc` and then destroying it: 323MB still allocated at exit, ~100% of it `MonoType::makeType` → `unique_refc_map::get` (Record/Func/TVar nodes, the `std::set<std::string>` each `Record` builds, hash-map slots, control blocks). Nothing from LLVM/ORC.

## How

`CompactMTypeMemoryAtExit` (already in `type.H`, used by the net/prepl handlers) declared as `cc`'s first data member, so its destructor runs after every other member — the type environment, the jit and its `globalExprs`, the search and regex caches — has dropped its references. Only entries with no remaining reference are erased; types shared with another live `cc` stay.

## Measured

Same driver, RSS after `malloc_trim`, `cc` destroyed after the third compile (Release, clang 18 / LLVM 18; 22MB before any `cc`, 68MB with a fresh one):

| table | before | after |
|---|---|---|
| 400×12 columnwise | 482MB | 60MB |
| 70×12 columnwise | 139MB | 49MB |
| 70×12 row-pivot | ~530MB | 63MB |

What a live `cc` still retains per compile is the annotated expression of every drained definition (`jitcc::globalExprs`, kept for inlining); that goes with the `cc`, as before.

## Tests

`Compiler/destroyingCCReleasesItsTypes`: interns a record type nobody else will, holds a `weak_ptr` to it, destroys the `cc`, expects the weak pointer expired. Fails without the member, passes with it. Full suite: 206/206.

## Docs

The recompiling guide's budget section said destroying a `cc` reclaims 10–20% (measured before this change). It now gives resident size after destruction, and mentions `compactMTypeMemory()` for a long-lived `cc` that wants the growth back between compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)