### PR TITLE
Fix the AFL++ dry-run timeout in fuzz-parse-expr; make hobbes::cc construction ~20% faster

### DIFF
--- a/fuzz/fuzz_parse_expr.C
+++ b/fuzz/fuzz_parse_expr.C
@@ -23,14 +23,24 @@
 // So two things are done periodically, one for each half. The type memo is
 // compacted every few dozen inputs, as the decoder harnesses do; that gives
 // back the memo's half and costs about as much as a parse. The compiler is
-// replaced every thousand or so; that gives back its half, and costs the
-// fraction of a second it takes to build one, amortised over enough inputs
-// not to show. Neither alone is enough: each leaves the other half growing
-// without bound. Counts of inputs are a coarse stand-in for how much has
-// accumulated, but a portable and predictable one -- resident size is not,
-// because freeing memory does not hand it back to the operating system, so a
-// harness that watched RSS rebuilt the compiler on every input once it first
-// went over.
+// replaced every couple of thousand inputs that could have compiled a regex;
+// that gives back its half, and costs what it takes to build one. Neither
+// alone is enough: each leaves the other half growing without bound. Counts
+// of inputs are a coarse stand-in for how much has accumulated, but a
+// portable and predictable one -- resident size is not, because freeing
+// memory does not hand it back to the operating system, so a harness that
+// watched RSS rebuilt the compiler on every input once it first went over.
+//
+// Building a compiler is the one expensive thing this harness does: it
+// compiles the bootstrap modules, about half a second unsanitized and several
+// seconds under ASan. That matters under AFL++, whose driver forks a fresh
+// process for the run and times every input against a fixed budget (OSS-Fuzz
+// runs it with -t 5000+): a compiler built on the first input is charged to
+// that input, and the seed corpus dry run then fails the build with a timeout
+// before fuzzing starts. So the first compiler is built in
+// LLVMFuzzerInitialize, which every driver runs before the fork server and
+// before any input is timed. Replacements still land inside a timed input;
+// counting only the inputs that can have grown the compiler keeps them rare.
 
 #include <hobbes/hobbes.H>
 
@@ -69,15 +79,15 @@ extern "C" const char* __lsan_default_suppressions() {
 
 namespace {
 
-const unsigned long inputsPerCompaction = 64;
-const unsigned long inputsPerCompiler   = 1024;
+const unsigned long inputsPerCompaction  = 64;
+const unsigned long regexInputsPerCompiler = 2048;
 
-// The first compiler is built in the initializer rather than on first use.
-// Constructing a cc also constructs the LLVM statics it depends on, and at
-// exit everything static is destroyed in reverse order of construction: a slot
-// that was registered empty and filled afterwards would be destroyed after
-// those statics, and the cc inside it would tear down against an LLVM context
-// that was already gone.
+// The first compiler is built in the slot's initializer rather than on first
+// use. Constructing a cc also constructs the LLVM statics it depends on, and
+// at exit everything static is destroyed in reverse order of construction: a
+// slot that was registered empty and filled afterwards would be destroyed
+// after those statics, and the cc inside it would tear down against an LLVM
+// context that was already gone.
 std::unique_ptr<hobbes::cc>& compilerSlot() {
   static std::unique_ptr<hobbes::cc> c(new hobbes::cc());
   return c;
@@ -91,10 +101,21 @@ hobbes::cc& compiler() {
   return *c;
 }
 
-void reclaimPeriodically() {
+// A regex literal is quoted with single quotes, and nothing else the reader
+// does leaves anything behind in the compiler, so an input without a quote
+// cannot have grown it. (A quote is also how a character literal and a
+// quote inside a string look, and a match can be defined before the parse
+// that holds it fails, so this is a superset: inputs that could have compiled
+// a regex, not inputs that did.)
+bool mayHaveCompiledRegex(const std::string& src) {
+  return src.find('\'') != std::string::npos;
+}
+
+void reclaimPeriodically(bool grewCompiler) {
   static unsigned long read = 0;
+  static unsigned long regexReads = 0;
   ++read;
-  if (read % inputsPerCompiler == 0) {
+  if (grewCompiler && ++regexReads % regexInputsPerCompiler == 0) {
     compilerSlot().reset();
   }
   if (read % inputsPerCompaction == 0) {
@@ -106,6 +127,11 @@ void reclaimPeriodically() {
 
 } // namespace
 
+extern "C" int LLVMFuzzerInitialize(int*, char***) {
+  compiler();
+  return 0;
+}
+
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   std::string src(reinterpret_cast<const char*>(data), size);
   try {
@@ -113,6 +139,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   } catch (const std::exception&) {
     // rejecting malformed source is the expected behavior
   }
-  reclaimPeriodically();
+  reclaimPeriodically(mayHaveCompiledRegex(src));
   return 0;
 }

--- a/fuzz/standalone_main.C
+++ b/fuzz/standalone_main.C
@@ -15,7 +15,11 @@ extern "C" __attribute__((weak)) int LLVMFuzzerInitialize(int* argc, char*** arg
 
 int main(int argc, char** argv) {
   if (LLVMFuzzerInitialize != nullptr) {
-    LLVMFuzzerInitialize(&argc, &argv);
+    int rc = LLVMFuzzerInitialize(&argc, &argv);
+    if (rc != 0) {
+      fprintf(stderr, "LLVMFuzzerInitialize failed: %d\n", rc);
+      return rc;
+    }
   }
   for (int i = 1; i < argc; ++i) {
     FILE* f = fopen(argv[i], "rb");

--- a/fuzz/standalone_main.C
+++ b/fuzz/standalone_main.C
@@ -9,7 +9,14 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
 
+// optional, as it is for libFuzzer: a harness that has one-time setup
+// defines it, and the engines run it before the first input
+extern "C" __attribute__((weak)) int LLVMFuzzerInitialize(int* argc, char*** argv);
+
 int main(int argc, char** argv) {
+  if (LLVMFuzzerInitialize != nullptr) {
+    LLVMFuzzerInitialize(&argc, &argv);
+  }
   for (int i = 1; i < argc; ++i) {
     FILE* f = fopen(argv[i], "rb");
     if (f == nullptr) {

--- a/include/hobbes/lang/pat/dfa.H
+++ b/include/hobbes/lang/pat/dfa.H
@@ -196,7 +196,10 @@ struct MDFA {
   ExprIdxs       exprIdxs;
   bool           inPrimSel;
 
-  str::set rootVars;
+  // the state functions lifted out of this match so far. Together with the
+  // compiler's global environment these are the names a folded state must not
+  // take as parameters (see liftDFAExpr)
+  str::set liftedStateFns;
   cc*      c;
 
   // every regex a column of the match can test, keyed by the column's

--- a/lib/hobbes/lang/pat/dfa.C
+++ b/lib/hobbes/lang/pat/dfa.C
@@ -1538,15 +1538,24 @@ ExprPtr liftDFAExpr(MDFA* dfa, stateidx_t state) {
       dfa->inlinedStates = 0;
       ExprPtr  def   = liftDFAExprWithSwitchCompression(dfa, state);
       dfa->inlinedStates = outerInlined;
-      str::set fvnst = setDifference(freeVars(def), dfa->rootVars);
-      str::seq fvns  = str::seq(fvnst.begin(), fvnst.end());
+      // the state function takes the variables it uses as arguments, except
+      // those it can reach anyway: globals, and the state functions lifted
+      // before it. Asking the environment about each free variable is much
+      // cheaper than enumerating every global for every fold (boot alone
+      // folds over six hundred states against thousands of globals)
+      str::seq fvns;
+      for (const auto& fvn : freeVars(def)) {
+        if (dfa->liftedStateFns.count(fvn) == 0 && !dfa->c->typeEnv()->hasBinding(fvn)) {
+          fvns.push_back(fvn);
+        }
+      }
 
       std::string stateFn = ".patfs." + str::from(state);
       ExprPtr callexp = fncall(varName(dfa, stateFn), vars(fvns, dfa->rootLA), dfa->rootLA);
 
       dfa->foldedStates.push_back(FoldedState(stateFn, ExprPtr(new Fn(fvns, def, dfa->rootLA))));
       dfa->foldedStateCalls[state] = callexp;
-      dfa->rootVars.insert(stateFn);
+      dfa->liftedStateFns.insert(stateFn);
 
       return callexp;
     }
@@ -1555,7 +1564,6 @@ ExprPtr liftDFAExpr(MDFA* dfa, stateidx_t state) {
 
 ExprPtr liftDFAExpr(cc* c, const PatternRows& ps, const LexicalAnnotation& rootLA) {
   MDFA pdfa;
-  pdfa.rootVars  = c->typeEnv()->boundVariables();
   pdfa.c         = c;
   pdfa.inPrimSel = false;
 

--- a/lib/hobbes/lang/preds/class.C
+++ b/lib/hobbes/lang/preds/class.C
@@ -898,6 +898,12 @@ ExprPtr unqualifyClass(const TEnvPtr& tenv, const std::string& cname, const Mono
 }
 
 bool isClassMember(const TEnvPtr& tenv, const std::string& memberName) {
+  // a name that isn't bound at all can't be a class member, and asking for its
+  // type would build a "did you mean" suggestion list from every binding in
+  // the environment before throwing
+  if (!tenv->hasBinding(memberName)) {
+    return false;
+  }
   try {
     Constraints cs = tenv->lookup(memberName)->qualtype()->constraints();
     return (cs.size() == 1) && (tenv->lookupUnqualifier(cs[0])->lookup(memberName) != PolyTypePtr());


### PR DESCRIPTION
## Why

The 2026-09-09 OSS-Fuzz build failed its AFL++ bad-build check for `fuzz-parse-expr` with a timeout. AFL++ times every input against a fixed `-t 5000+` (OSS-Fuzz's runner sets it; there is no per-project override), and the harness built its `hobbes::cc` lazily on the first input. Under ASan+UBSan construction takes ~5s, so the first seed was charged with it.

## What

**Harness (definitive fix):** the first compiler is now built in `LLVMFuzzerInitialize`, which every engine runs before the fork server and before any input is timed (AFL++ gives it 30s via `AFL_FORKSRV_INIT_TMOUT`). The standalone runner gains the same optional hook. Periodic compiler replacement still lands inside a timed input, so it is made rarer: only inputs that can have compiled a regex (the one thing the reader leaves behind in the compiler) are counted, and the compiler is replaced every 2048 of those instead of every 1024 inputs. Under ASan a replacement is still ~5s, so on AFL++ that will show as one spurious, non-reproducible hang per ~2048 regex-bearing inputs; libFuzzer's 25s timeout is unaffected.

**Compiler:** since construction cost benefits everyone, profiled `cc::cc()` (gprof) and removed two whole-environment walks on the path of every compiled match:

- `liftDFAExpr` snapshotted `TEnv::boundVariables()` per match (12k calls during boot), materialising every global just to tell which free variables of a folded state are globals. It now asks `hasBinding` per free variable — the same membership test.
- `isClassMember` did a `TEnv::lookup` on possibly-unbound names; a failed lookup builds a "did you mean" list over every binding before throwing. It now checks `hasBinding` first.

~17% of construction under gprof; release-build construction goes from ~800–850ms to ~600–700ms on the same machine (noisy box). ASan harness: 5.45s → 5.3s, so the structural fix above is what matters there.

Also tried and dropped: skipping `TCInstance::bind`'s re-validation for members `compileMembers` already normalized — not measurable above noise, not worth the API surface.

## Verification

- `hobbes-test` (Release, full suite): all pass.
- `build-memo` ASan+UBSan `fuzz-parse-expr` on `1+1`: libFuzzer reports `Executed in 0 ms` (construction moved out of the input).
- Standalone runner replays the checked-in corpus with the new init hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)