### PR TITLE
Fix five unambiguous bugs from the security audit: LALR UAF, net REPL double close, hog zlib/recovery, hi 404

### DIFF
--- a/bin/hi/www.C
+++ b/bin/hi/www.C
@@ -403,10 +403,15 @@ void WWWServer::printFileContents(int fd, const std::string& fpath) {
   int sfd = open(fpath.c_str(), O_RDONLY);
   if (sfd == -1) {
     print404(fd, fpath);
+    return;
   }
 
   struct stat sb;
-  fstat(sfd, &sb);
+  if (fstat(sfd, &sb) != 0) {
+    close(sfd);
+    print404(fd, fpath);
+    return;
+  }
 
   write(fd, "HTTP 200 OK\nContent-Type: " + mimeType(fpath) + "\nContent-Length: " + str::from(sb.st_size) + "\n\n");
 

--- a/bin/hog/batchrecv.C
+++ b/bin/hog/batchrecv.C
@@ -68,7 +68,9 @@ struct gzbuffer {
   void decompressChunk() {
     this->zin.next_out  = outb->data();
     this->zin.avail_out = outb->size();
-    checkZLibRC(static_cast<int>(inflate(&this->zin, Z_NO_FLUSH) < 0));
+    // hand checkZLibRC the return code itself: comparing it against zero first
+    // reduced every result to 0 or 1, so a corrupt segment was never reported
+    checkZLibRC(inflate(&this->zin, Z_NO_FLUSH));
     this->off   = 0;
     this->avail = this->outb->size() - this->zin.avail_out;
   }

--- a/bin/hog/recovery.C
+++ b/bin/hog/recovery.C
@@ -149,6 +149,14 @@ static bool hasBeenCorrectlyClosed(const std::vector<SenderState>& senderStates)
   return senderStates.empty() ? false : senderStates.back().status.value == SenderStatus::Enum::Closed;
 }
 
+static bool hasBeenCorrectlyClosed(const RecoveredDetails::SenderStateMap& senderStates, const hobbes::storage::ProcThread& senderId) {
+  // a sender that registered but never logged a state (it died before its
+  // first status record) has no entry at all, which is no more closed than
+  // an empty history is
+  auto ss = senderStates.find(senderId);
+  return ss != senderStates.end() && hasBeenCorrectlyClosed(ss->second);
+}
+
 struct RecoveryTask {
   const hobbes::storage::ProcThread writerId;
   const hobbes::storage::ProcThread readerId;
@@ -209,7 +217,7 @@ std::vector<RecoveryTask> getTasksRequiringRecovery(const RecoveredDetails& reco
     const SenderRegistration& senderReg = readerSenderReg.second;
 
     // is eligible for recovery
-    if (!hasBeenCorrectlyClosed(recoveredDetails.senderStates.find(senderReg.senderId)->second) && !hasBeenRecovered(recoveredDetails.sessionsRecovered, readerSenderReg)) {
+    if (!hasBeenCorrectlyClosed(recoveredDetails.senderStates, senderReg.senderId) && !hasBeenRecovered(recoveredDetails.sessionsRecovered, readerSenderReg)) {
       tasks.emplace_back(RecoveryTask{
         readerReg.writerId,
         senderReg.readerId, 

--- a/lib/hobbes/ipc/net.C
+++ b/lib/hobbes/ipc/net.C
@@ -321,7 +321,11 @@ void registerNetREPL(int s, Server *svr) {
             uint32_t version = 0;
             fdread(c, &version);
             if (version != 0x00010000) {
+              // the peer speaks another protocol: drop it here rather than
+              // falling through to register a handler on the closed socket
+              // (which then closed it again from the catch below)
               close(c);
+              return;
             }
 
             reinterpret_cast<Server *>(d)->connect(c);

--- a/lib/hobbes/parse/lalr.C
+++ b/lib/hobbes/parse/lalr.C
@@ -193,11 +193,15 @@ terminalset symbolsDerivingNull(const grammar& g) {
 
   while (changed) {
     changed = false;
-    for (auto s = potentials.begin(); s != potentials.end(); ++s) {
+    // erasing the element an iterator refers to invalidates that iterator, so
+    // advance from what erase returns rather than incrementing the dead one
+    for (auto s = potentials.begin(); s != potentials.end(); ) {
       if (nulls.find(*s) == nulls.end() && derivesNull(g, nulls, *s)) {
         nulls.insert(*s);
-        potentials.erase(*s);
+        s = potentials.erase(s);
         changed = true;
+      } else {
+        ++s;
       }
     }
   }

--- a/test/Net.C
+++ b/test/Net.C
@@ -3,12 +3,16 @@
 #include <hobbes/hobbes.H>
 #include <hobbes/ipc/net.H>
 #include <hobbes/net.H>
+#include <hobbes/util/codec.H>
 
 #include <atomic>
 #include <condition_variable>
 #include <cstdlib>
 #include <mutex>
 #include <thread>
+
+#include <sys/socket.h>
+#include <unistd.h>
 
 using namespace hobbes;
 
@@ -285,6 +289,23 @@ TEST(Net, syncClientAPI) {
   auto inv = c.inverse(RGB{{0, 255, 0}});
   EXPECT_EQ(std::vector<int>(inv.val, inv.val + 3),
             std::vector<int>({255, 0, 255}));
+}
+
+TEST(Net, rejectedHandshakeLeavesTheServerServing) {
+  // a peer that opens with a protocol version the server does not speak is
+  // dropped at the handshake. The drop used to fall through to register an
+  // event handler on the socket it had just closed; that registration failed,
+  // and the failure path closed the socket a second time -- by then possibly
+  // some other thread's. The peer should simply see its connection closed,
+  // and the next client should be served as usual.
+  int fd = connectSocket("localhost", testServerPort());
+  fdwrite(fd, static_cast<uint32_t>(0xdeadbeef));
+  char b = 0;
+  EXPECT_EQ(::recv(fd, &b, 1, 0), ssize_t(0)); // orderly EOF: the server hung up
+  ::close(fd);
+
+  SyncClient c("localhost", testServerPort());
+  EXPECT_EQ(c.add(1, 2), 3);
 }
 
 TEST(Net, syncClientAPIWithConfiguredHostName) {

--- a/test/Parse.C
+++ b/test/Parse.C
@@ -217,3 +217,23 @@ TEST(Parse, AFailedParseLeavesNoLexerStateBehind) {
   EXPECT_EQ(openParseCount(), size_t(0));
   EXPECT_EQ(show(c().readExpr("1+2")), "+(1, 2)");
 }
+
+// a parser generated from a `parse { ... }` grammar first works out which of
+// its rules can derive the empty string. That pass walked a set while erasing
+// from it -- erasing the element its iterator named, then stepping the dead
+// iterator -- which is undefined behaviour reached by any grammar with a rule
+// that can be empty (a debug libstdc++ reports "attempt to increment a
+// singular iterator"; an ordinary build reads freed memory and may crash or
+// mis-classify a rule). Nullable rules are common (an optional prefix, an
+// empty list), so the parser they produce should just work.
+TEST(Parse, GrammarsWithNullableRulesAreGenerated) {
+  // O is nullable directly, P only through O: both must be seen as such for
+  // "a" to be accepted at all
+  cc lc;
+  lc.define("np", "parse { S := p:P \"a\" { p }   P := o:O { o }   O := \"b\" { 1 } | { 0 } }");
+
+  EXPECT_EQ(lc.compileFn<int()>("match np(\"a\")  with | |1=x| -> x | _ -> -1")(), 0);
+  EXPECT_EQ(lc.compileFn<int()>("match np(\"ba\") with | |1=x| -> x | _ -> -1")(), 1);
+  EXPECT_EQ(lc.compileFn<int()>("match np(\"bb\") with | |1=x| -> x | _ -> -1")(), -1);
+  EXPECT_EQ(lc.compileFn<int()>("match np(\"\")   with | |1=x| -> x | _ -> -1")(), -1);
+}


### PR DESCRIPTION
## Summary

Five small, independent fixes from a full-repo audit, each a plain coding bug with no design tradeoff. One commit per fix; each message explains the trigger and the reasoning.

| Fix | Where | Effect before |
|---|---|---|
| Erase-during-iteration in the LALR nullable-symbol pass | `lib/hobbes/parse/lalr.C` | `std::set::erase(*s)` then `++s` on the dead iterator — UB reached by any `parse { … }` grammar with an empty rule (`_GLIBCXX_DEBUG`: "attempt to increment a singular iterator") |
| Net REPL accept handler used a socket it had just closed | `lib/hobbes/ipc/net.C` | Bad protocol version → `close(c)` with no `return`, then `registerEventHandler` on the closed fd throws, and the catch closes `c` a second time — by then possibly another thread's descriptor |
| zlib return code discarded in hog `batchrecv` | `bin/hog/batchrecv.C` | `checkZLibRC(inflate(...) < 0)` handed the checker `0`/`1`, never the rc — corrupt segments (CRC failure) and truncated segments were accepted as complete and written to the store |
| `fstat(-1)` after a failed `open` in hi's static file handler | `bin/hi/www.C` | 404 sent, then a 200 with an uninitialised `Content-Length` and a `sendfile` loop from fd −1 |
| Unchecked `map::find` in hog recovery | `bin/hog/recovery.C` | A sender that registered but died before its first state record → `find(...)->second` on `end()`, crashing hog at startup during recovery |

## Behaviour change worth a look

The `batchrecv` fix means a corrupt / truncated / empty compressed batch now terminates the log session with `failed to decompress out of gzip segment (rc)` (the sender then resends from its segment files) instead of being silently acked. Verified standalone with the same `gzbuffer` logic over a 3 MB payload: complete streams behave identically before and after; corrupt (−3), truncated (−5) and empty (−5) inputs go from "complete" to raising. A finished gzip member keeps returning `Z_STREAM_END`, which is how `eof()` is detected, so it is unaffected.

## Copilot follow-ups

- `689317a`: `gzbuffer` no longer inflates in its constructor (a throw there skipped `inflateEnd`), and `checkZLibRC` rejects `Z_NEED_DICT`, which is positive but produces no output and read as an empty, complete batch.
- `ffe6d66`: with corrupt segments now rejected, a batch was applied up to the point the CRC failure surfaced (the trailer), and the sender's resend applied it again. A batch is now decoded in full before any of it is applied. Standalone check on a 1000-transaction batch: trailer CRC flipped, old loop applied 784 then rejected; truncated, 999; the new loop applies 0 in both cases.
- `da8171a`: a claimed transaction length near 2^64 wrapped `off + n`, so the resize came out short of the read (ASan: 4000-byte heap overflow). The buffer now grows 64 KiB at a time as data is actually read, so a false length fails at the first unsatisfiable read with nothing applied.

## Tests

- New `Parse/GrammarsWithNullableRulesAreGenerated` — a grammar with a directly nullable rule and one nullable only transitively; accepts/rejects the right strings.
- New `Net/rejectedHandshakeLeavesTheServerServing` — a raw client sends a bogus version word, sees an orderly EOF, and the next real client is served.
- The `hi`/`hog` paths have no unit harness; `hi` and `hog` build clean.
- Full `hobbes-test` suite passes on Linux/LLVM 18 (Debug).

## Not in this PR

Noticed while here, left for a follow-up: `registerEventHandler` (`events.C`) leaves a dangling `epClosures` entry when `epoll_ctl` fails, and `batchrecv` stops after the first gzip member, so a segment file re-opened in `"ab"` mode after a crash would have its later members dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


